### PR TITLE
Depend on stable versions of ably-cocoa (v1.2.5) - which has breaking changes

### DIFF
--- a/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,13 +5,13 @@
         "package": "ably-cocoa",
         "repositoryURL": "https://github.com/ably/ably-cocoa",
         "state": {
-          "branch": "feature/SPM-rc",
-          "revision": "afe138765b81921bf09a92449cbbe8cd8de50512",
-          "version": null
+          "branch": null,
+          "revision": "c474bba8e74bac408423bc8d3e542a1ed3482138",
+          "version": "1.2.5"
         }
       },
       {
-        "package": "amplify-ios",
+        "package": "Amplify",
         "repositoryURL": "https://github.com/aws-amplify/amplify-ios",
         "state": {
           "branch": null,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "package": "aws-appsync-realtime-client-ios",
+        "package": "AppSyncRealTimeClient",
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
@@ -29,7 +29,7 @@
         }
       },
       {
-        "package": "aws-sdk-ios-spm",
+        "package": "AWSiOSSDKV2",
         "repositoryURL": "https://github.com/aws-amplify/aws-sdk-ios-spm.git",
         "state": {
           "branch": null,
@@ -38,16 +38,16 @@
         }
       },
       {
-        "package": "delta-codec-cocoa",
+        "package": "AblyDeltaCodec",
         "repositoryURL": "https://github.com/ably/delta-codec-cocoa",
         "state": {
-          "branch": "main",
-          "revision": "d09d34a5489665a3c924a95791ce0a97ef26cc99",
-          "version": null
+          "branch": null,
+          "revision": "8bb8ad568acf0c0a3d0208389c41b133925c5c64",
+          "version": "1.3.1"
         }
       },
       {
-        "package": "mapbox-common-ios",
+        "package": "MapboxCommon",
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
@@ -56,7 +56,7 @@
         }
       },
       {
-        "package": "mapbox-core-maps-ios",
+        "package": "MapboxCoreMaps",
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
@@ -65,7 +65,7 @@
         }
       },
       {
-        "package": "mapbox-directions-swift",
+        "package": "MapboxDirections",
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
@@ -74,7 +74,7 @@
         }
       },
       {
-        "package": "mapbox-events-ios",
+        "package": "MapboxMobileEvents",
         "repositoryURL": "https://github.com/mapbox/mapbox-events-ios.git",
         "state": {
           "branch": null,
@@ -83,7 +83,7 @@
         }
       },
       {
-        "package": "mapbox-maps-ios",
+        "package": "MapboxMaps",
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
@@ -92,7 +92,7 @@
         }
       },
       {
-        "package": "mapbox-navigation-ios",
+        "package": "MapboxNavigation",
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-ios.git",
         "state": {
           "branch": null,
@@ -101,7 +101,7 @@
         }
       },
       {
-        "package": "mapbox-navigation-native-ios",
+        "package": "MapboxNavigationNative",
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
@@ -110,7 +110,7 @@
         }
       },
       {
-        "package": "mapbox-speech-swift",
+        "package": "MapboxSpeech",
         "repositoryURL": "https://github.com/mapbox/mapbox-speech-swift.git",
         "state": {
           "branch": null,
@@ -119,7 +119,7 @@
         }
       },
       {
-        "package": "MapboxGeocoder.swift",
+        "package": "MapboxGeocoder",
         "repositoryURL": "https://github.com/mapbox/MapboxGeocoder.swift.git",
         "state": {
           "branch": null,
@@ -128,7 +128,7 @@
         }
       },
       {
-        "package": "msgpack-objective-C",
+        "package": "msgpack",
         "repositoryURL": "https://github.com/rvi/msgpack-objective-C",
         "state": {
           "branch": null,
@@ -245,7 +245,7 @@
         }
       },
       {
-        "package": "turf-swift",
+        "package": "Turf",
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,

--- a/Examples/PublisherExample/PublisherExample.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExample/PublisherExample.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		AD5BCAF02677C3CB00836F16 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = AD5BCAEF2677C3CB00836F16 /* AWSCognitoAuthPlugin */; };
 		AD5BCAF22677C3CB00836F16 /* AWSPluginsCore in Frameworks */ = {isa = PBXBuildFile; productRef = AD5BCAF12677C3CB00836F16 /* AWSPluginsCore */; };
 		AD5BCAF42677C3CB00836F16 /* AWSS3StoragePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = AD5BCAF32677C3CB00836F16 /* AWSS3StoragePlugin */; };
-		AD909F64267CD38A004247D6 /* AblyAssetTrackingPublisher in Frameworks */ = {isa = PBXBuildFile; productRef = AD909F63267CD38A004247D6 /* AblyAssetTrackingPublisher */; };
+		AD650D2F26CAA3A300099610 /* AblyAssetTrackingPublisher in Frameworks */ = {isa = PBXBuildFile; productRef = AD650D2E26CAA3A300099610 /* AblyAssetTrackingPublisher */; };
 		AD909F66267CD3ED004247D6 /* AWSAPIPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = AD909F65267CD3ED004247D6 /* AWSAPIPlugin */; };
 		F618BA8625C9939000B69885 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A7DADD25C96F26001C094B /* Environment.swift */; };
 		F67E661C25F8E21B001CF9BB /* DescriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67E661B25F8E21B001CF9BB /* DescriptionsHelper.swift */; };
@@ -78,11 +78,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD909F66267CD3ED004247D6 /* AWSAPIPlugin in Frameworks */,
+				AD650D2F26CAA3A300099610 /* AblyAssetTrackingPublisher in Frameworks */,
 				AD5BCAF42677C3CB00836F16 /* AWSS3StoragePlugin in Frameworks */,
 				AD5BCAF22677C3CB00836F16 /* AWSPluginsCore in Frameworks */,
 				AD5BCAEE2677C3CB00836F16 /* Amplify in Frameworks */,
 				AD5BCAF02677C3CB00836F16 /* AWSCognitoAuthPlugin in Frameworks */,
-				AD909F64267CD38A004247D6 /* AblyAssetTrackingPublisher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,8 +242,8 @@
 				AD5BCAEF2677C3CB00836F16 /* AWSCognitoAuthPlugin */,
 				AD5BCAF12677C3CB00836F16 /* AWSPluginsCore */,
 				AD5BCAF32677C3CB00836F16 /* AWSS3StoragePlugin */,
-				AD909F63267CD38A004247D6 /* AblyAssetTrackingPublisher */,
 				AD909F65267CD3ED004247D6 /* AWSAPIPlugin */,
+				AD650D2E26CAA3A300099610 /* AblyAssetTrackingPublisher */,
 			);
 			productName = PublisherExample;
 			productReference = 180F60F3258632D90014B310 /* PublisherExample.app */;
@@ -556,7 +556,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ably/ably-asset-tracking-swift";
 			requirement = {
-				branch = "148/swift-package-manager";
+				branch = main;
 				kind = branch;
 			};
 		};
@@ -583,9 +583,8 @@
 			package = AD5BCAEC2677C3CB00836F16 /* XCRemoteSwiftPackageReference "amplify-ios" */;
 			productName = AWSS3StoragePlugin;
 		};
-		AD909F63267CD38A004247D6 /* AblyAssetTrackingPublisher */ = {
+		AD650D2E26CAA3A300099610 /* AblyAssetTrackingPublisher */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = AD909F62267CD38A004247D6 /* XCRemoteSwiftPackageReference "ably-asset-tracking-swift" */;
 			productName = AblyAssetTrackingPublisher;
 		};
 		AD909F65267CD3ED004247D6 /* AWSAPIPlugin */ = {

--- a/Examples/SubscriberExample/SubscriberExample.xcodeproj/project.pbxproj
+++ b/Examples/SubscriberExample/SubscriberExample.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = XXY98AVDR6;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -424,6 +425,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = XXY98AVDR6;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -464,7 +466,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ably/ably-asset-tracking-swift";
 			requirement = {
-				branch = "148/swift-package-manager";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,18 +5,18 @@
         "package": "ably-cocoa",
         "repositoryURL": "https://github.com/ably/ably-cocoa",
         "state": {
-          "branch": "feature/SPM-rc",
-          "revision": "afe138765b81921bf09a92449cbbe8cd8de50512",
-          "version": null
+          "branch": null,
+          "revision": "c474bba8e74bac408423bc8d3e542a1ed3482138",
+          "version": "1.2.5"
         }
       },
       {
         "package": "AblyDeltaCodec",
         "repositoryURL": "https://github.com/ably/delta-codec-cocoa",
         "state": {
-          "branch": "main",
-          "revision": "d09d34a5489665a3c924a95791ce0a97ef26cc99",
-          "version": null
+          "branch": null,
+          "revision": "18bd35a49f155b2be22babed1eaafe11e767caab",
+          "version": "1.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,7 @@ let package = Package(
         .package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", .exact("2.0.0-beta.14")),
         .package(url: "https://github.com/realm/SwiftLint", from: "0.43.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
-//        // TODO Release a version of Ably-cocoa supporting SPM, and use it here instead of using a branch.
-//        .package(url: "https://github.com/ably/ably-cocoa", from: "NEW_VERSION"),
-            .package(url: "https://github.com/ably/ably-cocoa", .branch("feature/SPM-rc"))
+       .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.5")
         ],
     targets: [
         .target(

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
@@ -20,11 +20,11 @@ class DefaultAblyPublisherService: AblyPublisherService {
 
     private func setup() {
         client.connection.on { [weak self] stateChange in
-            guard let self = self,
-                  let receivedConnectionState = stateChange?.current.toConnectionState() else {
+            guard let self = self else {
                 return
             }
 
+            let receivedConnectionState = stateChange.current.toConnectionState()
             logger.debug("Connection to Ably changed. New state: \(receivedConnectionState)", source: "DefaultAblyPublisherService")
             self.delegate?.publisherService(
                 sender: self,
@@ -66,11 +66,11 @@ class DefaultAblyPublisherService: AblyPublisherService {
         }
 
         channel.on { [weak self] stateChange in
-            guard let self = self,
-                  let receivedConnectionState = stateChange?.current.toConnectionState() else {
+            guard let self = self else {
                 return
             }
 
+            let receivedConnectionState = stateChange.current.toConnectionState()
             logger.debug("Channel state for trackable \(trackable.id) changed. New state: \(receivedConnectionState)", source: "DefaultAblyPublisherService")
             self.delegate?.publisherService(sender: self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
         }
@@ -122,16 +122,13 @@ class DefaultAblyPublisherService: AblyPublisherService {
 
     private func closeClientConnection(completion: @escaping ResultHandler<Void>) {
         client.connection.on { connectionChange in
-            guard let connectionState = connectionChange?.current else {
-                return
-            }
-
+            let connectionState = connectionChange.current
             switch connectionState {
             case .closed:
                 logger.info("Ably connection closed successfully.")
                 completion(.success)
             case .failed:
-                let errorInfo = connectionChange?.reason?.toErrorInformation() ?? ErrorInformation(type: .publisherError(errorMessage: "Cannot close connection"))
+                let errorInfo = connectionChange.reason?.toErrorInformation() ?? ErrorInformation(type: .publisherError(errorMessage: "Cannot close connection"))
                 completion(.failure(errorInfo))
             default:
                 return

--- a/Sources/AblyAssetTrackingSubscriber/Services/DefaultAblySubscriberService.swift
+++ b/Sources/AblyAssetTrackingSubscriber/Services/DefaultAblySubscriberService.swift
@@ -87,21 +87,21 @@ class DefaultAblySubscriberService: AblySubscriberService {
     // MARK: Utils
     private func setup() {
         client.connection.on { [weak self] connectionState in
-            guard let self = self,
-                  let receivedConnectionState = connectionState?.current.toConnectionState() else {
+            guard let self = self else {
                 return
             }
             
+            let receivedConnectionState = connectionState.current.toConnectionState()
             logger.debug("Connection to Ably changed. New state: \(receivedConnectionState)", source: "DefaultAblyPublisherService")
             self.delegate?.subscriberService(sender: self, didChangeClientConnectionStatus: receivedConnectionState)
         }
         
         channel.on { [weak self] channelStatus in
-            guard let self = self,
-                  let receivedConnectionState = channelStatus?.current.toConnectionState() else {
+            guard let self = self else {
                 return
             }
             
+            let receivedConnectionState = channelStatus.current.toConnectionState()
             logger.debug("Channel connection state changed. New state: \(receivedConnectionState)", source: "DefaultAblyPublisherService")
             self.delegate?.subscriberService(sender: self, didChangeChannelConnectionStatus: receivedConnectionState)
         }


### PR DESCRIPTION
To install a release (version number) of this SDK into their Xcode project/ swift packages, this library needs to depend on stable version (e.g. a git tag instead of a branch). 

This should be merged before this SDK is released with SPM support.