### PR TITLE
Manage stopping strategy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/realm/SwiftLint", from: "0.43.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.4.2"),
         .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.6")
-    ],
+        ],
     targets: [
         //
         // Targets


### PR DESCRIPTION
Stoping strategy functionality was added before, either for the Subscriber and the Publisher.
I've added a missing test for Publisher only.

This PR is branched on https://github.com/ably/ably-asset-tracking-swift/tree/134/add-token-based-authentication, which is not merged to `main` yet, so merging this one is blocked until it's base branch will be merged to `main` 