### PR TITLE
Explicitly specify workflow `permissions` required to succeed when our org switches default access from 'permissive' to 'restricted'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      deployments: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Initial prototype: https://github.com/ably/ably-asset-tracking-android/pull/441

See [this internal Slack thread](https://ably-real-time.slack.com/archives/CF7GGBF2N/p1631814436061500) for more context.