### PR TITLE
Remove `didFailWithError` delegate call causing side effect. 

### DIFF
--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
@@ -84,10 +84,16 @@ class DefaultAblyPublisherService: AblyPublisherService {
             completion?(.failure(errorInformation))
             return
         }
-
-        guard let message = try? createARTMessage(for: locationUpdate) else {
-            let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Cannot create location update message."))
-            self.delegate?.publisherService(sender: self, didFailWithError: errorInformation)
+        
+        let message: ARTMessage
+        do {
+            message = try createARTMessage(for: locationUpdate)
+        } catch {
+            let errorInformation = ErrorInformation(
+                type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
+            )
+            delegate?.publisherService(sender: self, didFailWithError: errorInformation)
+            
             return
         }
 
@@ -106,7 +112,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         }
     }
     
-    private func createARTMessage(for locationUpdate: EnhancedLocationUpdate) throws -> ARTMessage? {
+    private func createARTMessage(for locationUpdate: EnhancedLocationUpdate) throws -> ARTMessage {
         let geoJson = try EnhancedLocationUpdateMessage(locationUpdate: locationUpdate)
         let data = try geoJson.toJSONString()
         

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
@@ -85,7 +85,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
             return
         }
 
-        guard let message = createARTMessage(for: locationUpdate) else {
+        guard let message = try? createARTMessage(for: locationUpdate) else {
             let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Cannot create location update message."))
             self.delegate?.publisherService(sender: self, didFailWithError: errorInformation)
             return
@@ -105,16 +105,12 @@ class DefaultAblyPublisherService: AblyPublisherService {
             completion?(.success)
         }
     }
-
-    private func createARTMessage(for locationUpdate: EnhancedLocationUpdate) -> ARTMessage? {
-        do {
-            let geoJson = try EnhancedLocationUpdateMessage(locationUpdate: locationUpdate)
-            let data = try geoJson.toJSONString()
-            return ARTMessage(name: EventName.enhanced.rawValue, data: data)
-        } catch let error {
-            self.delegate?.publisherService(sender: self, didFailWithError: ErrorInformation(error: error))
-            return nil
-        }
+    
+    private func createARTMessage(for locationUpdate: EnhancedLocationUpdate) throws -> ARTMessage? {
+        let geoJson = try EnhancedLocationUpdateMessage(locationUpdate: locationUpdate)
+        let data = try geoJson.toJSONString()
+        
+        return ARTMessage(name: EventName.enhanced.rawValue, data: data)
     }
 
     func close(completion: @escaping ResultHandler<Void>) {


### PR DESCRIPTION
It's not the ideal solution but it's the fastest.
We have to consider do we want to tell the user what exactly happened (detailed error) or we just want to tell the user that there is something wrong with `creating ART message`.
This is the original idea 02ee9741c8f326be558add7d6c7c4529ea758d3f

EDIT:
I decided to refactor the code and "tell" the user what cause the error in detail c1d67db8d7c24ebdd4ebe5b14446bd2fecc93060