### PR TITLE
Remove objective-c layer

### DIFF
--- a/Examples/PublisherExample/Sources/Screens/AddTrackable/AddTrackableViewController.swift
+++ b/Examples/PublisherExample/Sources/Screens/AddTrackable/AddTrackableViewController.swift
@@ -143,7 +143,7 @@ class AddTrackableViewController: UIViewController {
                     return
                 }
                 
-                switch result {
+                switch result.enumUnwrap {
                 case .success:
                     self.delegate?.addTrackableViewController(sender: self, onTrackableAdded: trackable)
                     self.dismiss(animated: true, completion: nil)

--- a/Examples/PublisherExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/PublisherExample/Sources/Screens/Map/MapViewController.swift
@@ -112,7 +112,7 @@ class MapViewController: UIViewController {
         locationState = .pending
 
         publisher?.track(trackable: trackable) { [weak self] result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 self?.trackables = [trackable]
                 logger.info("Initial trackable tracked successfully.")
@@ -124,10 +124,10 @@ class MapViewController: UIViewController {
         }
     }
 
-    private func closePublisher(completion: ResultHandler<Void>?) {
+    private func closePublisher(completion: ResultHandler?) {
         trackables.removeAll()
         publisher?.stop { [weak self] result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 logger.info("Publisher closed successfully.")
                 self?.locationState = .failed
@@ -224,7 +224,7 @@ class MapViewController: UIViewController {
         setRoutingProfileAvtivityIndicatorState(isLoading: true)
         publisher?.changeRoutingProfile(profile: routingProfile) { [weak self] result in
             self?.setRoutingProfileAvtivityIndicatorState(isLoading: false)
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 self?.routingProfileLabel.text = DescriptionsHelper.RoutingProfileDescHelper.getDescription(for: routingProfile)
             case .failure(let error):

--- a/Examples/PublisherExample/Sources/Screens/Trackables/TrackablesViewController.swift
+++ b/Examples/PublisherExample/Sources/Screens/Trackables/TrackablesViewController.swift
@@ -89,7 +89,7 @@ extension TrackablesViewController: UITableViewDelegate, UITableViewDataSource {
         publisher?.remove(trackable: trackableToRemove) { [weak self] result in
             guard let self = self else { return }
             
-            switch result {
+            switch result.enumUnwrap(Bool.self) {
             case .success(let wasPresent):
                 let trackable = self.trackables.remove(at: indexPath.row)
                 self.tableView.reloadData()

--- a/Examples/PublisherExampleObjectiveC/PublisherExampleObjectiveC.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleObjectiveC/PublisherExampleObjectiveC.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		AD909F5B267CD2B1004247D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AD909F55267CD2B1004247D6 /* Assets.xcassets */; };
 		AD909F5C267CD2B1004247D6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD909F56267CD2B1004247D6 /* LaunchScreen.storyboard */; };
 		AD909F5D267CD2B1004247D6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD909F58267CD2B1004247D6 /* Main.storyboard */; };
+		D5BDB6582754F564000189EB /* AblyAssetTrackingPublisher in Frameworks */ = {isa = PBXBuildFile; productRef = D5BDB6572754F564000189EB /* AblyAssetTrackingPublisher */; };
 		D5EBC15F274B7FF800F4A16D /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = D5EBC15E274B7FF800F4A16D /* Amplify */; };
-		D5EBC162274B801200F4A16D /* AblyAssetTrackingPublisher in Frameworks */ = {isa = PBXBuildFile; productRef = D5EBC161274B801200F4A16D /* AblyAssetTrackingPublisher */; };
 		D5EBC164274B801200F4A16D /* AWSAPIPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = D5EBC163274B801200F4A16D /* AWSAPIPlugin */; };
 		D5EBC166274B801200F4A16D /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = D5EBC165274B801200F4A16D /* AWSCognitoAuthPlugin */; };
 		D5EBC168274B801200F4A16D /* AWSDataStorePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = D5EBC167274B801200F4A16D /* AWSDataStorePlugin */; };
@@ -49,7 +49,7 @@
 		AD909F5A267CD2B1004247D6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D58D2F25269C40D100693374 /* PublisherExampleObjectiveC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PublisherExampleObjectiveC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D58D2F26269C40D100693374 /* PublisherExampleObjectiveCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PublisherExampleObjectiveCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5EBC15C274B7F0F00F4A16D /* ably-asset-tracking-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ably-asset-tracking-swift"; path = ../..; sourceTree = "<group>"; };
+		D5BDB6562753E7D4000189EB /* ably-asset-tracking-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ably-asset-tracking-swift"; path = ../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,11 +60,11 @@
 				D5EBC16A274B801200F4A16D /* AWSLocationGeoPlugin in Frameworks */,
 				D5EBC164274B801200F4A16D /* AWSAPIPlugin in Frameworks */,
 				D5EBC15F274B7FF800F4A16D /* Amplify in Frameworks */,
-				D5EBC162274B801200F4A16D /* AblyAssetTrackingPublisher in Frameworks */,
 				D5EBC16E274B801200F4A16D /* AWSPluginsCore in Frameworks */,
 				D5EBC168274B801200F4A16D /* AWSDataStorePlugin in Frameworks */,
 				D5EBC166274B801200F4A16D /* AWSCognitoAuthPlugin in Frameworks */,
 				D5EBC16C274B801200F4A16D /* AWSPinpointAnalyticsPlugin in Frameworks */,
+				D5BDB6582754F564000189EB /* AblyAssetTrackingPublisher in Frameworks */,
 				D5EBC170274B801200F4A16D /* AWSS3StoragePlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -107,7 +107,7 @@
 		D5EBC15B274B7F0F00F4A16D /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				D5EBC15C274B7F0F00F4A16D /* ably-asset-tracking-swift */,
+				D5BDB6562753E7D4000189EB /* ably-asset-tracking-swift */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -149,7 +149,6 @@
 			name = PublisherExampleObjectiveC;
 			packageProductDependencies = (
 				D5EBC15E274B7FF800F4A16D /* Amplify */,
-				D5EBC161274B801200F4A16D /* AblyAssetTrackingPublisher */,
 				D5EBC163274B801200F4A16D /* AWSAPIPlugin */,
 				D5EBC165274B801200F4A16D /* AWSCognitoAuthPlugin */,
 				D5EBC167274B801200F4A16D /* AWSDataStorePlugin */,
@@ -157,6 +156,7 @@
 				D5EBC16B274B801200F4A16D /* AWSPinpointAnalyticsPlugin */,
 				D5EBC16D274B801200F4A16D /* AWSPluginsCore */,
 				D5EBC16F274B801200F4A16D /* AWSS3StoragePlugin */,
+				D5BDB6572754F564000189EB /* AblyAssetTrackingPublisher */,
 			);
 			productName = PublisherExampleObjectiveC;
 			productReference = D58D2F25269C40D100693374 /* PublisherExampleObjectiveC.app */;
@@ -520,14 +520,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D5BDB6572754F564000189EB /* AblyAssetTrackingPublisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AblyAssetTrackingPublisher;
+		};
 		D5EBC15E274B7FF800F4A16D /* Amplify */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D5EBC15D274B7FF800F4A16D /* XCRemoteSwiftPackageReference "amplify-ios" */;
 			productName = Amplify;
-		};
-		D5EBC161274B801200F4A16D /* AblyAssetTrackingPublisher */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AblyAssetTrackingPublisher;
 		};
 		D5EBC163274B801200F4A16D /* AWSAPIPlugin */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/PublisherExampleObjectiveC/Sources/ViewController.m
+++ b/Examples/PublisherExampleObjectiveC/Sources/ViewController.m
@@ -53,7 +53,7 @@
                             constraints:NULL];
     
     [self.publisher trackWithTrackable:trackable
-                            completion:^(ATResult * _Nonnull result) {
+                            completion:^(AATResult * _Nonnull result) {
         if(result.failure != nil) {
             NSLog(@"Track trackable ERROR: %@", result.failure.message);
         } else if (result.success != nil) {
@@ -70,7 +70,7 @@
                             constraints:NULL];
     
     [self.publisher addWithTrackable:trackable
-                          completion:^(ATResult * _Nonnull result) {
+                          completion:^(AATResult * _Nonnull result) {
         if (result.failure != nil) {
             NSLog(@"Add trackable ERROR: %@", result.failure.message);
         } else if (result.success != nil) {
@@ -81,7 +81,7 @@
 
 - (void) publisherChangeRoutingProfileUsageExample {
     [self.publisher changeRoutingProfileWithProfile:RoutingProfileWalking
-                                         completion:^(ATResult * _Nonnull result) {
+                                         completion:^(AATResult * _Nonnull result) {
         if (result.failure != nil) {
             NSLog(@"Change routing profile ERROR: %@", result.failure.message);
         } else if (result.success != nil) {
@@ -98,7 +98,7 @@
                             constraints:NULL];
     
     [self.publisher removeWithTrackable:trackable
-                             completion:^(ATResult * _Nonnull result) {
+                             completion:^(AATResult * _Nonnull result) {
         if (result.failure != nil) {
             NSLog(@"Remove trackable ERROR: %@", result.failure.message);
         } else if (result.success != nil) {

--- a/Examples/PublisherExampleObjectiveC/Sources/ViewController.m
+++ b/Examples/PublisherExampleObjectiveC/Sources/ViewController.m
@@ -42,6 +42,7 @@
                       resolutionPolicyFactory:resolutionPolicy]
                       delegate:delegate]
                       startAndReturnError:NULL];
+
 }
 
 - (void) publisherTrackUsageExample {
@@ -50,12 +51,14 @@
                             metadata:NULL
                             destination:CLLocationCoordinate2DMake(0.0, 0.0)
                             constraints:NULL];
-
+    
     [self.publisher trackWithTrackable:trackable
-      onSuccess:^() {
-        NSLog(@"Track trackable SUCCESS");
-    } onError: ^(ErrorInformation * _Nonnull error) {
-        NSLog(@"Track trackable ERROR: %@", error.message);
+                            completion:^(ATResult * _Nonnull result) {
+        if(result.failure != nil) {
+            NSLog(@"Track trackable ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Track trackable SUCCESS");
+        }
     }];
 }
 
@@ -67,19 +70,23 @@
                             constraints:NULL];
     
     [self.publisher addWithTrackable:trackable
-      onSuccess:^() {
-        NSLog(@"Add trackable SUCCESS");
-    } onError: ^(ErrorInformation * _Nonnull error) {
-        NSLog(@"Add trackable ERROR: %@", error.message);
+                          completion:^(ATResult * _Nonnull result) {
+        if (result.failure != nil) {
+            NSLog(@"Add trackable ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Add trackable SUCCESS");
+        }
     }];
 }
 
 - (void) publisherChangeRoutingProfileUsageExample {
     [self.publisher changeRoutingProfileWithProfile:RoutingProfileWalking
-      onSuccess:^() {
-        NSLog(@"Change routing profile SUCCESS");
-    } onError:^(ErrorInformation * _Nonnull error) {
-        NSLog(@"Change routing profile ERROR: %@", error.message);
+                                         completion:^(ATResult * _Nonnull result) {
+        if (result.failure != nil) {
+            NSLog(@"Change routing profile ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Change routing profile SUCCESS");
+        }
     }];
 }
 
@@ -91,10 +98,12 @@
                             constraints:NULL];
     
     [self.publisher removeWithTrackable:trackable
-      onSuccess:^(BOOL wasPresent) {
-        NSLog(@"Remove trackable SUCCESS. WasPresent: %s", wasPresent ? "TRUE" : "FALSE");
-    } onError:^(ErrorInformation * _Nonnull error) {
-        NSLog(@"Remove trackable ERROR: %@", error.message);
+                             completion:^(ATResult * _Nonnull result) {
+        if (result.failure != nil) {
+            NSLog(@"Remove trackable ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Remove trackable SUCCESS. WasPresent: %s", result.success ? "TRUE" : "FALSE");
+        }
     }];
 }
 

--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
@@ -83,7 +83,7 @@ class MapViewController: UIViewController {
             .resolution(Resolution(accuracy: .balanced, desiredInterval: 10000, minimumDisplacement: 500))
             .delegate(self)
             .start { [weak self] result in
-                switch result {
+                switch result.enumUnwrap {
                 case .success:
                     logger.info("Subscriber started successfully.")
                 case .failure(let error):
@@ -151,7 +151,7 @@ class MapViewController: UIViewController {
         }
 
         subscriber?.resolutionPreference(resolution: resolution) { [weak self] result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 self?.currentResolution = resolution
                 self?.updateResolutionLabel()

--- a/Examples/SubscriberExampleObjectiveC/Sources/ViewController.m
+++ b/Examples/SubscriberExampleObjectiveC/Sources/ViewController.m
@@ -32,10 +32,12 @@
                         log:logConfiguration]
                         resolution:resolution]
                         delegate:delegate]
-                        startOnSuccess:^() {
-                            NSLog(@"Subscriber start SUCCESS");
-                        } onError:^(ErrorInformation * _Nonnull error) {
-                            NSLog(@"Subscriber start ERROR: %@", error.message);
+                        startWithCompletion:^(ATResult * _Nonnull result) {
+                            if (result.failure != nil) {
+                                NSLog(@"Subscriber start ERROR: %@", result.failure.message);
+                            } else if (result.success != nil) {
+                                NSLog(@"Subscriber start SUCCESS");
+                            }
     }];
     
     NSLog(@"Subscriber created: %s", self.subscriber == NULL ? "FALSE" : "TRUE");
@@ -46,19 +48,24 @@
                                                   desiredInterval:1000
                                               minimumDisplacement:1000];
     
-    [self.subscriber resolutionPreferenceWithResolution:resolution
-                                              onSuccess:^() {
-                                                NSLog(@"Send resolution preference SUCCESS");
-                                              } onError:^(ErrorInformation * _Nonnull error) {
-                                                NSLog(@"Send resolution preference ERROR: %@", error.message);
+    [self.subscriber
+     resolutionPreferenceWithResolution:resolution
+     completion:^(ATResult * _Nonnull result) {
+        if (result.failure != nil) {
+            NSLog(@"Send resolution preference ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Send resolution preference SUCCESS");
+        }
     }];
 }
 
 - (void) subscriberStopUsageExample {
-    [self.subscriber stopOnSuccess:^() {
-        NSLog(@"Subscriber stop SUCCESS");
-    } onError:^(ErrorInformation * _Nonnull error) {
-        NSLog(@"Subscriber stop ERROR: %@", error.message);
+    [self.subscriber stopWithCompletion:^(ATResult * _Nonnull result) {
+        if (result.failure != nil) {
+            NSLog(@"Send resolution preference ERROR: %@", result.failure.message);
+        } else if (result.success != nil) {
+            NSLog(@"Subscriber stop SUCCESS");
+        }
     }];
 }
 

--- a/Examples/SubscriberExampleObjectiveC/Sources/ViewController.m
+++ b/Examples/SubscriberExampleObjectiveC/Sources/ViewController.m
@@ -32,7 +32,7 @@
                         log:logConfiguration]
                         resolution:resolution]
                         delegate:delegate]
-                        startWithCompletion:^(ATResult * _Nonnull result) {
+                        startWithCompletion:^(AATResult * _Nonnull result) {
                             if (result.failure != nil) {
                                 NSLog(@"Subscriber start ERROR: %@", result.failure.message);
                             } else if (result.success != nil) {
@@ -50,7 +50,7 @@
     
     [self.subscriber
      resolutionPreferenceWithResolution:resolution
-     completion:^(ATResult * _Nonnull result) {
+     completion:^(AATResult * _Nonnull result) {
         if (result.failure != nil) {
             NSLog(@"Send resolution preference ERROR: %@", result.failure.message);
         } else if (result.success != nil) {
@@ -60,7 +60,7 @@
 }
 
 - (void) subscriberStopUsageExample {
-    [self.subscriber stopWithCompletion:^(ATResult * _Nonnull result) {
+    [self.subscriber stopWithCompletion:^(AATResult * _Nonnull result) {
         if (result.failure != nil) {
             NSLog(@"Send resolution preference ERROR: %@", result.failure.message);
         } else if (result.success != nil) {

--- a/Sources/AblyAssetTrackingCore/ResultHandler.swift
+++ b/Sources/AblyAssetTrackingCore/ResultHandler.swift
@@ -39,24 +39,19 @@ public class AATResult: NSObject, Resultable {
 }
 
 public extension AATResult {
-    enum Unwrapped<T> {
-        case success(T)
-        case failure(ErrorInformation)
-    }
-    
-    var enumUnwrap: Unwrapped<Void> {
-        if let failure = failure {
-            return .failure(failure)
+    var unwrap: Result<Void, ErrorInformation> {
+        if let value = failure {
+            return .failure(value)
         }
         
         return .success(Void())
     }
     
-    func enumUnwrap<T>(_:T.Type) -> Unwrapped<T> {
-        if let failure = failure {
-            return .failure(failure)
-        } else if let success = success {
-            if let casted = success as? T {
+    func unwrap<T>(_ :T.Type) -> Result<T, ErrorInformation> {
+        if let value = failure {
+            return .failure(value)
+        } else if let value = success {
+            if let casted = value as? T {
                 return .success(casted)
             } else {
                 fatalError("Unable to cast \(type(of: success)) to `\(T.self)`")

--- a/Sources/AblyAssetTrackingCore/ResultHandler.swift
+++ b/Sources/AblyAssetTrackingCore/ResultHandler.swift
@@ -1,10 +1,68 @@
-/**
- Completion handler for operations
- */
-public typealias ResultHandler<T: Any> = (Result<T, ErrorInformation>) -> Void
+import Foundation
 
-public extension Result where Success == Void {
-    static var success: Result {
+public typealias ResultHandler = (ATResult) -> Void
+
+@objc
+public protocol Resultable {
+    var success: Any? { get }
+    var failure: ErrorInformation? { get }
+}
+
+@objcMembers
+public class ATResult: NSObject, Resultable {
+    public let success: Any?
+    public let failure: ErrorInformation?
+    
+    public static var success: ATResult {
+        return .init(success: Void(), failure: nil)
+    }
+    
+    public static func success(_ value: Any?) -> ATResult {
+        return .init(success: value, failure: nil)
+    }
+    
+    public static func failure(_ value: ErrorInformation?) -> ATResult {
+        return .init(success: nil, failure: value)
+    }
+    
+    public init(success: Any? = nil, failure: ErrorInformation? = nil) {
+        self.success = success
+        self.failure = failure
+    }
+    
+    public override init() {
+        self.success = nil
+        self.failure = nil
+        
+        super.init()
+    }
+}
+
+public extension ATResult {
+    enum Unwrapped<T> {
+        case success(T)
+        case failure(ErrorInformation)
+    }
+    
+    var enumUnwrap: Unwrapped<Void> {
+        if let failure = failure {
+            return .failure(failure)
+        }
+        
         return .success(Void())
+    }
+    
+    func enumUnwrap<T>(_:T.Type) -> Unwrapped<T> {
+        if let failure = failure {
+            return .failure(failure)
+        } else if let success = success {
+            if let casted = success as? T {
+                return .success(casted)
+            } else {
+                fatalError("Unable to cast \(type(of: success)) to `\(T.self)`")
+            }
+        }
+        
+        return .success(Void() as! T)
     }
 }

--- a/Sources/AblyAssetTrackingCore/ResultHandler.swift
+++ b/Sources/AblyAssetTrackingCore/ResultHandler.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public typealias ResultHandler = (ATResult) -> Void
+public typealias ResultHandler = (AATResult) -> Void
 
 @objc
 public protocol Resultable {
@@ -9,19 +9,19 @@ public protocol Resultable {
 }
 
 @objcMembers
-public class ATResult: NSObject, Resultable {
+public class AATResult: NSObject, Resultable {
     public let success: Any?
     public let failure: ErrorInformation?
     
-    public static var success: ATResult {
+    public static var success: AATResult {
         return .init(success: Void(), failure: nil)
     }
     
-    public static func success(_ value: Any?) -> ATResult {
+    public static func success(_ value: Any?) -> AATResult {
         return .init(success: value, failure: nil)
     }
     
-    public static func failure(_ value: ErrorInformation?) -> ATResult {
+    public static func failure(_ value: ErrorInformation?) -> AATResult {
         return .init(success: nil, failure: value)
     }
     
@@ -38,7 +38,7 @@ public class ATResult: NSObject, Resultable {
     }
 }
 
-public extension ATResult {
+public extension AATResult {
     enum Unwrapped<T> {
         case success(T)
         case failure(ErrorInformation)

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -205,13 +205,13 @@ extension DefaultPublisher {
         }
 
         self.ablyService.track(trackable: event.trackable) { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .failure(let error):
                 self?.callback(error: error, handler: event.resultHandler)
                 return
             case .success:
                 self?.enqueue(event: PresenceJoinedSuccessfullyEvent(trackable: event.trackable) { [weak self] result in
-                    switch result.enumUnwrap {
+                    switch result.unwrap {
                     case .success:
                         self?.enqueue(event: TrackableReadyToTrackEvent(trackable: event.trackable, resultHandler: event.resultHandler))
                     default:
@@ -233,7 +233,7 @@ extension DefaultPublisher {
             hooks.trackables?.onActiveTrackableChanged(trackable: event.trackable)
             if let destination = event.trackable.destination {
                 routeProvider.getRoute(to: destination, withRoutingProfile: routingProfile) { [weak self] result in
-                    switch result.enumUnwrap(Route.self) {
+                    switch result.unwrap(Route.self) {
                     case .success(let route):
                         self?.enqueue(event: SetDestinationSuccessEvent(route: route))
                     case .failure(let error):
@@ -270,7 +270,7 @@ extension DefaultPublisher {
         }
 
         routeProvider.changeRoutingProfile(to: routingProfile) { [weak self] result in
-            switch result.enumUnwrap(Route.self) {
+            switch result.unwrap(Route.self) {
             case .success(let route):
                 self?.routingProfile = event.profile
                 self?.enqueue(event: SetDestinationSuccessEvent(route: route))
@@ -301,7 +301,7 @@ extension DefaultPublisher {
         }
 
         self.ablyService.track(trackable: event.trackable) { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 self?.enqueue(event: PresenceJoinedSuccessfullyEvent(trackable: event.trackable) { [weak self] _ in
                     self?.callback(value: Void(), handler: event.resultHandler)
@@ -320,7 +320,7 @@ extension DefaultPublisher {
         }
 
         self.ablyService.stopTracking(trackable: event.trackable) { [weak self] result in
-            switch result.enumUnwrap(Bool.self) {
+            switch result.unwrap(Bool.self) {
             case .success(let wasPresent):
                 self?.trackableState.remove(trackableId: event.trackable.id)
                 wasPresent
@@ -342,7 +342,7 @@ extension DefaultPublisher {
         state = .stopping
 
         ablyService.close { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 self?.locationService.stopUpdatingLocation()
                 self?.enqueue(event: AblyConnectionClosedEvent(resultHandler: event.resultHandler))
@@ -497,7 +497,7 @@ extension DefaultPublisher {
 
         trackableState.markMessageAsPending(for: trackable.id)
         ablyService.sendEnhancedAssetLocationUpdate(locationUpdate: event.locationUpdate, forTrackable: trackable) { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .failure(let error):
                 self?.enqueue(event: SendEnhancedLocationFailureEvent(error: error, locationUpdate: event.locationUpdate, trackable: trackable))
             case .success:

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -10,7 +10,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
     private var routingProfile: RoutingProfile?
     private var resolutionPolicyFactory: ResolutionPolicyFactory?
     private weak var delegate: PublisherDelegate?
-    private weak var delegateObjectiveC: PublisherDelegateObjectiveC?
 
     override init() { }
 
@@ -20,7 +19,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                  locationSource: LocationSource?,
                  routingProfile: RoutingProfile?,
                  delegate: PublisherDelegate?,
-                 delegateObjectiveC: PublisherDelegateObjectiveC?,
                  resolutionPolicyFactory: ResolutionPolicyFactory?) {
         self.connection = connection
         self.mapboxConfiguration = mapboxConfiguration
@@ -28,7 +26,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
         self.locationSource = locationSource
         self.routingProfile = routingProfile
         self.delegate = delegate
-        self.delegateObjectiveC = delegateObjectiveC
         self.resolutionPolicyFactory = resolutionPolicyFactory
     }
 
@@ -67,7 +64,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                           locationService: DefaultLocationService(mapboxConfiguration: mapboxConfiguration, historyLocation: locationSource?.locationSource),
                                           routeProvider: DefaultRouteProvider(mapboxConfiguration: mapboxConfiguration))
         publisher.delegate = delegate
-        publisher.delegateObjectiveC = nil
         return publisher
     }
     
@@ -78,7 +74,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
     
@@ -89,7 +84,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
     
@@ -100,7 +94,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
     
@@ -111,7 +104,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: source,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
     
@@ -122,7 +114,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: profile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
 
@@ -133,7 +124,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: nil,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
     
@@ -144,133 +134,6 @@ class DefaultPublisherBuilder: NSObject, PublisherBuilder {
                                        locationSource: locationSource,
                                        routingProfile: routingProfile,
                                        delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-}
-
-extension DefaultPublisherBuilder: PublisherBuilderObjectiveC {
-    @objc
-    func start() throws -> PublisherObjectiveC {
-        guard let connection = connection
-        else {
-            throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "ConnectionConfiguration", forBuilderOption: "connection"))
-        }
-        
-        guard let mapboxConfiguration = mapboxConfiguration
-        else {
-            throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "MapboxConfiguration", forBuilderOption: "mapboxConfiguration"))
-        }
-
-        guard let logConfiguration = logConfiguration
-        else {
-            throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "LogConfiguration", forBuilderOption: "log"))
-        }
-
-        guard let routingProfile = routingProfile
-        else {
-            throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "RoutingProfile", forBuilderOption: "routingProfile"))
-        }
-
-        guard let resolutionPolicyFactory = resolutionPolicyFactory
-        else {
-            throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "ResolutionPolicyFactory", forBuilderOption: "resolutionPolicyFactory"))
-        }
-        
-        let publisher =  DefaultPublisher(connectionConfiguration: connection,
-                                          mapboxConfiguration: mapboxConfiguration,
-                                          logConfiguration: logConfiguration,
-                                          routingProfile: routingProfile,
-                                          resolutionPolicyFactory: resolutionPolicyFactory,
-                                          ablyService: DefaultAblyPublisherService(configuration: connection),
-                                          locationService: DefaultLocationService(mapboxConfiguration: mapboxConfiguration, historyLocation: locationSource?.locationSource),
-                                          routeProvider: DefaultRouteProvider(mapboxConfiguration: mapboxConfiguration))
-        publisher.delegate = nil
-        publisher.delegateObjectiveC = delegateObjectiveC
-        return publisher
-    }
-    
-    @objc
-    func connection(_ configuration: ConnectionConfiguration) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: configuration,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: locationSource,
-                                       routingProfile: routingProfile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-    
-    @objc
-    func mapboxConfiguration(_ mapboxConfiguration: MapboxConfiguration) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: locationSource,
-                                       routingProfile: routingProfile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-    
-    @objc
-    func log(_ configuration: LogConfiguration) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: configuration,
-                                       locationSource: locationSource,
-                                       routingProfile: routingProfile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-    
-    @objc
-    func locationSource(_ source: LocationSource?) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: source,
-                                       routingProfile: routingProfile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-    
-    @objc
-    func routingProfile(_ profile: RoutingProfile) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: locationSource,
-                                       routingProfile: profile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: resolutionPolicyFactory)
-    }
-    
-    @objc
-    func resolutionPolicyFactory(_ factory: ResolutionPolicyFactory) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: locationSource,
-                                       routingProfile: routingProfile,
-                                       delegate: delegate,
-                                       delegateObjectiveC: delegateObjectiveC,
-                                       resolutionPolicyFactory: factory)
-    }
-    
-    @objc
-    func delegate(_ delegate: PublisherDelegateObjectiveC) -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder(connection: connection,
-                                       mapboxConfiguration: mapboxConfiguration,
-                                       logConfiguration: logConfiguration,
-                                       locationSource: locationSource,
-                                       routingProfile: routingProfile,
-                                       delegate: nil,
-                                       delegateObjectiveC: delegate,
                                        resolutionPolicyFactory: resolutionPolicyFactory)
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
@@ -7,37 +7,37 @@ protocol PublisherEvent {}
 
 struct TrackTrackableEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct AddTrackableEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct RemoveTrackableEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Bool>
+    let resultHandler: ResultHandler/*Bool*/
 }
 
 struct ClearActiveTrackableEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Bool>
+    let resultHandler: ResultHandler/*Bool*/
 }
 
 struct ClearRemovedTrackableMetadataEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Bool>
+    let resultHandler: ResultHandler/*Bool*/
 }
 
 struct PresenceJoinedSuccessfullyEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct TrackableReadyToTrackEvent: PublisherEvent {
     let trackable: Trackable
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct SetDestinationSuccessEvent: PublisherEvent {
@@ -65,7 +65,7 @@ struct ChangeLocationEngineResolutionEvent: PublisherEvent {}
 
 struct ChangeRoutingProfileEvent: PublisherEvent {
     let profile: RoutingProfile
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct PresenceUpdateEvent: PublisherEvent {
@@ -76,11 +76,11 @@ struct PresenceUpdateEvent: PublisherEvent {
 }
 
 struct StopEvent: PublisherEvent {
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct AblyConnectionClosedEvent: PublisherEvent {
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct AblyClientConnectionStateChangedEvent: PublisherEvent {

--- a/Sources/AblyAssetTrackingPublisher/Publisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/Publisher.swift
@@ -2,93 +2,9 @@ import Foundation
 import AblyAssetTrackingCore
 
 /**
- Main `PublisherObjectiveC` interface implemented in SDK by `DefaultPublisher`
- */
-@objc(Publisher)
-public protocol PublisherObjectiveC: AnyObject {
-    /**
-     Delegate object to receive events from `PublisherObjectiveC`.
-     It holds a weak reference so make sure to keep your delegate object in memory.
-     */
-    @objc var delegateObjectiveC: PublisherDelegateObjectiveC? { get set }
-    
-    /**
-     The actively tracked object, being the `Trackable` object whose destination will be used for location
-     enhancement, if available.
-     This state can be changed by calling the [track] method.
-     */
-    @objc var activeTrackable: Trackable? { get }
-    
-    /**
-     Represents active mean of transport used by the publisher.
-     */
-    @objc var routingProfile: RoutingProfile { get }
-
-    /**
-     Adds a `Trackable` object and makes it the actively tracked object, meaning that the state of the `activeTrackable` property
-     will be updated to this object, if that wasn't already the case.
-     If this object was already in this publisher's tracked set then this method only serves to change the actively
-     tracked object.
-     
-     - Parameters:
-        - trackable The object to be added to this publisher's tracked set, if it's not already there, and to be made the actively tracked object.
-        - onSuccess called when the trackable is successfully added and make the actively tracked object.
-        - onError called when an error occurs.
-     */
-    @objc
-    func track(trackable: Trackable, onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-    
-    /**
-     Adds a `Trackable` object, but does not make it the actively tracked object, meaning that the state of the
-     `activeTrackable` property will not change.
-     If this object was already in this publisher's tracked set then this method does nothing.
-     
-     - Parameters:
-        - trackable: The object to be added to this publisher's tracked set, if it's not already there.
-        - onSuccess called when the trackable is successfully added.
-        - onError called when an error occurs.
-     */
-    @objc
-    func add(trackable: Trackable, onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-    
-    /**
-     Removes a `Trackable` property if it is known to this publisher, otherwise does nothing and returns false.
-     If the removed object is the current actively `active` object then that state will be cleared, meaning that for
-     another object to become the actively tracked delivery then the `track` method must be subsequently called.
-     
-     - Parameters:
-        - trackable: The object to be removed from this publisher's tracked set, if it's there.
-        - onSuccess called when the removing was successful, wasPresent is true when the object was known to this publisher, being that it was in the tracked set.
-        - onError called when an error occurs.
-     */
-    @objc
-    func remove(trackable: Trackable, onSuccess: @escaping ((Bool) -> Void), onError: @escaping ((ErrorInformation) -> Void))
-    
-    /**
-     Changes the current routing profile.
-     
-     - Parameters:
-        - profile: The routing profile to be used from now on.
-        - onSuccess: called when RoutingProfile is successfuly changed.
-        - onError: called when an error occurs.
-    */
-    @objc
-    func changeRoutingProfile(profile: RoutingProfile, onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-    
-    /**
-     Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
-     
-     - Parameters:
-        - onSuccess: called when the Publisher stopped successfuly.
-        - onError: called when an error occurs.
-     */
-    @objc
-    func stop(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-}
-
-/**
  Main `Publisher` interface implemented in SDK by `DefaultPublisher`
  */
+@objc
 public protocol Publisher {
     /**
      Delegate object to receive events from `Publisher`.
@@ -108,7 +24,7 @@ public protocol Publisher {
             - `success` when the trackable is successfully added and make the actively tracked object.
             - `failure` when an error occurs.
      */
-    func track(trackable: Trackable, completion: @escaping ResultHandler<Void>)
+    func track(trackable: Trackable, completion: @escaping ResultHandler/*Void*/)
 
     /**
      Adds a `Trackable` object, but does not make it the actively tracked object, meaning that the state of the
@@ -121,7 +37,7 @@ public protocol Publisher {
             - `success` when the trackable is successfully added.
             - `failure` when an error occurs.
      */
-    func add(trackable: Trackable, completion: @escaping ResultHandler<Void>)
+    func add(trackable: Trackable, completion: @escaping ResultHandler/*Void*/)
 
     /**
      Removes a `Trackable` property if it is known to this publisher, otherwise does nothing and returns false.
@@ -134,7 +50,7 @@ public protocol Publisher {
             - `success` when the removing was successful, wasPresent is true when the object was known to this publisher, being that it was in the tracked set.
             - `failure` when an error occurs.
      */
-    func remove(trackable: Trackable, completion: @escaping ResultHandler<Bool>)
+    func remove(trackable: Trackable, completion: @escaping ResultHandler/*Bool*/)
 
     /**
      The actively tracked object, being the `Trackable` object whose destination will be used for location
@@ -157,7 +73,7 @@ public protocol Publisher {
             - `success` when RoutingProfile is successfuly changed.
             - `failure` when an error occurs.
     */
-    func changeRoutingProfile(profile: RoutingProfile, completion: @escaping ResultHandler<Void>)
+    func changeRoutingProfile(profile: RoutingProfile, completion: @escaping ResultHandler/*Void*/)
 
     /**
      Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
@@ -167,5 +83,5 @@ public protocol Publisher {
             - `success` called when the Publisher stopped successfuly.
             - `failure` when an error occurs.
     */
-    func stop(completion: @escaping ResultHandler<Void>) 
+    func stop(completion: @escaping ResultHandler/*Void*/)
 }

--- a/Sources/AblyAssetTrackingPublisher/PublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherBuilder.swift
@@ -4,65 +4,7 @@ import AblyAssetTrackingCore
 /**
  Default and preferred way to create the `Publisher`.
  */
-
-@objc(PublisherBuilder)
-public protocol PublisherBuilderObjectiveC: AnyObject {
-    /**
-     Creates a `Publisher` which is ready to publish the asset location to subscribers.
-     Notice that it needs asset to track - it can be set using `Publisher.track()` function.
-     - throws: `AssetTrackingError.incompleteConfiguration`  in case of missing mandatory property
-     - Returns: `Publisher`  ready to `track` the asset.
-     */
-    @objc
-    func start() throws -> PublisherObjectiveC
-    
-    /**
-     Sets the mandatory `ConnectionConfiguration` property
-     */
-    @objc
-    func connection(_ configuration: ConnectionConfiguration) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `MapboxConfiguration` property
-    */
-    @objc
-    func mapboxConfiguration(_ mapboxConfiguration: MapboxConfiguration) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `LogConfiguration` property
-     */
-    @objc
-    func log(_ configuration: LogConfiguration) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the optional `LocationSource` property
-     */
-    @objc
-    func locationSource(_ source: LocationSource?) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `RoutingProfile` property
-     */
-    @objc
-    func routingProfile(_ profile: RoutingProfile) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `ResolutionPolicyFactory` property
-     */
-    @objc
-    func resolutionPolicyFactory(_ factory: ResolutionPolicyFactory) -> PublisherBuilderObjectiveC
-    
-    /**
-     Sets the optional `Delegate` property.
-     It's optional to pass it via builder, as it can be set directly on `Publisher`.  Maintains weak reference.
-     */
-    @objc
-    func delegate(_ delegate: PublisherDelegateObjectiveC) -> PublisherBuilderObjectiveC
-}
-
-/**
- Default and preferred way to create the `Publisher`.
- */
+@objc
 public protocol PublisherBuilder {
     /**
      Creates a `Publisher` which is ready to publish the asset location to subscribers.

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -1,45 +1,7 @@
 import CoreLocation
 import AblyAssetTrackingCore
 
-@objc(PublisherDelegate)
-public protocol PublisherDelegateObjectiveC: AnyObject {
-    /**
-     Called when the `PublisherObjectiveC` spot any (location, network or permissions) error
-     
-     - Parameters:
-        - sender: `PublisherObjectiveC` instance.
-        - error: Detected error.
-     */
-    func publisher(sender: PublisherObjectiveC, didFailWithError error: ErrorInformation)
-    
-    /**
-     Called when the `PublisherObjectiveC` detect new enhanced (map matched) location. Same location will be sent to the Subscriber module
-     
-     - Parameters:
-        - sender:`PublisherObjectiveC` instance.
-        - location: Location object received from LocationManager
-     */
-    func publisher(sender: PublisherObjectiveC, didUpdateEnhancedLocation location: CLLocation)
-    
-    /**
-     Called when there is a connection update directly in AblySDK.
-     
-     - Parameters:
-        - sender:`PublisherObjectiveC` instance.
-        - state: Most recent connection state
-     */
-    func publisher(sender: PublisherObjectiveC, didChangeConnectionState state: ConnectionState)
-    
-    /**
-     Called when there is a resolution update directly in AblySDK.
-     
-     - Parameters:
-        - sender: `PublisherObjectiveC` instance.
-        - resolution: Most recent resolution.
-    */
-    func publisher(sender: PublisherObjectiveC, didUpdateResolution resolution: Resolution)
-}
-
+@objc
 public protocol PublisherDelegate: AnyObject {
     /**
      Called when the `Publisher` spot any (location, network or permissions) error

--- a/Sources/AblyAssetTrackingPublisher/PublisherFactory.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherFactory.swift
@@ -4,26 +4,13 @@ import AblyAssetTrackingCore
 /**
  Factory class used only to get `PublisherBuilder`
  */
-@objc(PublisherFactory)
-public class PublisherFactoryObjectiveC: NSObject {
-    /**
-     Returns the default state of the publisher `PublisherBuilderObjectiveC`, which is incapable of starting of  `Publisher`
-     instances until it has been configured fully.
-     */
-    @objc
-    static public func publishers() -> PublisherBuilderObjectiveC {
-        return DefaultPublisherBuilder()
-    }
-}
-
-/**
- Factory class used only to get `PublisherBuilder`
- */
-public class PublisherFactory {
+@objc
+public class PublisherFactory: NSObject {
     /**
      Returns the default state of the publisher `PublisherBuilder`, which is incapable of starting of  `Publisher`
      instances until it has been configured fully.
      */
+    @objc
     static public func publishers() -> PublisherBuilder {
         return DefaultPublisherBuilder()
     }

--- a/Sources/AblyAssetTrackingPublisher/Services/AblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/AblyPublisherService.swift
@@ -16,8 +16,8 @@ protocol AblyPublisherServiceDelegate: AnyObject {
 protocol AblyPublisherService: AnyObject {
     var delegate: AblyPublisherServiceDelegate? { get set }
 
-    func track(trackable: Trackable, completion: ResultHandler<Void>?)
-    func stopTracking(trackable: Trackable, completion: ResultHandler<Bool>?)
-    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler<Void>?)
-    func close(completion: @escaping ResultHandler<Void>)
+    func track(trackable: Trackable, completion: ResultHandler?/*Void*/)
+    func stopTracking(trackable: Trackable, completion: ResultHandler?/*Bool*/)
+    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler?/*Void*/)
+    func close(completion: @escaping ResultHandler/*Void*/)
 }

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
@@ -150,7 +150,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         channels.forEach { channel in
             closingDispatchGroup.enter()
             self.stopTracking(trackable: channel.key) { result in
-                switch result.enumUnwrap(Bool.self) {
+                switch result.unwrap(Bool.self) {
                 case .success(let wasPresent):
                     logger.info("Trackable \(channel.key.id) removed successfully. Was present \(wasPresent)")
                     closingDispatchGroup.leave()

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultAblyPublisherService.swift
@@ -35,7 +35,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
     }
 
     // MARK: Main interface
-    func track(trackable: Trackable, completion: ResultHandler<Void>?) {
+    func track(trackable: Trackable, completion: ResultHandler?/*Void*/) {
         // Force cast intentional here. It's a fatal error if we are unable to create presenceData JSON
         let data = try! presenceData.toJSONString()
 
@@ -78,7 +78,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         }
     }
 
-    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler<Void>?) {
+    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler?/*Void*/) {
         guard let channel = channels[trackable] else {
             let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Attempt to send location while not tracked channel"))
             completion?(.failure(errorInformation))
@@ -117,13 +117,13 @@ class DefaultAblyPublisherService: AblyPublisherService {
         }
     }
 
-    func close(completion: @escaping ResultHandler<Void>) {
+    func close(completion: @escaping ResultHandler/*Void*/) {
         closeAllChannels { _ in
             self.closeClientConnection(completion: completion)
         }
     }
 
-    private func closeClientConnection(completion: @escaping ResultHandler<Void>) {
+    private func closeClientConnection(completion: @escaping ResultHandler/*Void*/) {
         client.connection.on { connectionChange in
             switch connectionChange.current {
             case .closed:
@@ -140,7 +140,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         client.close()
     }
 
-    private func closeAllChannels(completion: @escaping ResultHandler<Void>) {
+    private func closeAllChannels(completion: @escaping ResultHandler/*Void*/) {
         guard !channels.isEmpty else {
             completion(.success)
             return
@@ -150,7 +150,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         channels.forEach { channel in
             closingDispatchGroup.enter()
             self.stopTracking(trackable: channel.key) { result in
-                switch result {
+                switch result.enumUnwrap(Bool.self) {
                 case .success(let wasPresent):
                     logger.info("Trackable \(channel.key.id) removed successfully. Was present \(wasPresent)")
                     closingDispatchGroup.leave()
@@ -167,7 +167,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         }
     }
 
-    func stopTracking(trackable: Trackable, completion: ResultHandler<Bool>?) {
+    func stopTracking(trackable: Trackable, completion: ResultHandler?/*Bool*/) {
         guard let channel = channels.removeValue(forKey: trackable) else {
             completion?(.success(false))
             return

--- a/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
@@ -3,13 +3,13 @@ import MapboxDirections
 import AblyAssetTrackingCore
 
 protocol RouteProvider {
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/)
+    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/)
 }
 
 class DefaultRouteProvider: NSObject, RouteProvider {
     private let locationManager: CLLocationManager
-    private var resultHandler: ResultHandler<Route>?
+    private var resultHandler: ResultHandler?/*Route*/
     private var destination: CLLocationCoordinate2D?
     private var routingProfile: RoutingProfile?
     private var directions: Directions?
@@ -21,7 +21,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
         super.init()
     }
 
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
         self.routingProfile = routingProfile
         guard let destination = self.destination,
               !isCalculating(resultHandler: completion) else {
@@ -33,7 +33,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
                  completion: completion)
     }
 
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
 
         if isCalculating(resultHandler: completion) {
             return
@@ -89,7 +89,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
         self.resultHandler = nil
     }
 
-    private func isCalculating(resultHandler: ResultHandler<Route>) -> Bool {
+    private func isCalculating(resultHandler: ResultHandler/*Route*/) -> Bool {
         guard self.resultHandler == nil
         else {
             let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Provider is already calculating route."))

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -54,7 +54,7 @@ class DefaultSubscriber: NSObject, Subscriber {
     @objc
     func resolutionPreference(resolution: Resolution?, onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) {
         resolutionPreference(resolution: resolution) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 onSuccess()
             case .failure(let error):
@@ -70,7 +70,7 @@ class DefaultSubscriber: NSObject, Subscriber {
     @objc
     func start(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) {
         start { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 onSuccess()
             case .failure(let error):
@@ -91,7 +91,7 @@ class DefaultSubscriber: NSObject, Subscriber {
     @objc
     func stop(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) {
         stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 onSuccess()
             case .failure(let error):
@@ -145,7 +145,7 @@ extension DefaultSubscriber {
     // MARK: Start/Stop
     private func performStart(_ event: StartEvent) {
         ablyService.start { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 self?.callback(value: Void(), handler: event.resultHandler)
             case .failure(let error):
@@ -158,7 +158,7 @@ extension DefaultSubscriber {
         subscriberState = .stopping
         
         ablyService.stop { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 self?.enqueue(event: AblyConnectionClosedEvent(resultHandler: event.resultHandler))
             case .failure(let error):
@@ -218,7 +218,7 @@ extension DefaultSubscriber {
     // swiftlint:disable vertical_whitespace_between_cases
     private func performChangeResolution(_ event: ChangeResolutionEvent) {
         ablyService.sendResolutionPreference(resolution: event.resolution) { [weak self] result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 self?.callback(value: Void(), handler: event.resultHandler)
             case .failure(let error):

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
@@ -7,7 +7,6 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
     private var trackingId: String?
     private var resolution: Resolution?
     private weak var delegate: SubscriberDelegate?
-    private weak var delegateObjectiveC: SubscriberDelegateObjectiveC?
 
     init() { }
 
@@ -15,17 +14,15 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                  logConfiguration: LogConfiguration?,
                  trackingId: String?,
                  resolution: Resolution?,
-                 delegate: SubscriberDelegate?,
-                 delegateObjectiveC: SubscriberDelegateObjectiveC?) {
+                 delegate: SubscriberDelegate?) {
         self.connection = connection
         self.logConfiguration = logConfiguration
         self.trackingId = trackingId
         self.resolution = resolution
         self.delegate = delegate
-        self.delegateObjectiveC = delegateObjectiveC
     }
 
-    func start(completion: @escaping ResultHandler<Void>) -> Subscriber? {
+    func start(completion: @escaping ResultHandler/*Void*/) -> Subscriber? {
         guard let connection = connection
         else {
             let error = ErrorInformation(type: .incompleteConfiguration(missingProperty: "ConnectionConfiguration", forBuilderOption: "connection"))
@@ -53,8 +50,8 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
         let subscriber = DefaultSubscriber(logConfiguration: logConfiguration,
                                            ablyService: ablyService)
         subscriber.delegate = delegate
-        subscriber.delegateObjectiveC = nil
         subscriber.start(completion: completion)
+        
         return subscriber
     }
 
@@ -63,8 +60,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                                         logConfiguration: logConfiguration,
                                         trackingId: trackingId,
                                         resolution: resolution,
-                                        delegate: delegate,
-                                        delegateObjectiveC: nil)
+                                        delegate: delegate)
     }
 
     func log(_ configuration: LogConfiguration) -> SubscriberBuilder {
@@ -72,8 +68,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                                         logConfiguration: configuration,
                                         trackingId: trackingId,
                                         resolution: resolution,
-                                        delegate: delegate,
-                                        delegateObjectiveC: nil)
+                                        delegate: delegate)
     }
 
     func trackingId(_ trackingId: String) -> SubscriberBuilder {
@@ -81,8 +76,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                                         logConfiguration: logConfiguration,
                                         trackingId: trackingId,
                                         resolution: resolution,
-                                        delegate: delegate,
-                                        delegateObjectiveC: nil)
+                                        delegate: delegate)
     }
 
     func resolution(_ resolution: Resolution) -> SubscriberBuilder {
@@ -90,8 +84,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                                         logConfiguration: logConfiguration,
                                         trackingId: trackingId,
                                         resolution: resolution,
-                                        delegate: delegate,
-                                        delegateObjectiveC: nil)
+                                        delegate: delegate)
     }
 
     func delegate(_ delegate: SubscriberDelegate) -> SubscriberBuilder {
@@ -99,87 +92,6 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
                                         logConfiguration: logConfiguration,
                                         trackingId: trackingId,
                                         resolution: resolution,
-                                        delegate: delegate,
-                                        delegateObjectiveC: nil)
-    }
-}
-
-extension DefaultSubscriberBuilder: SubscriberBuilderObjectiveC {
-    func start(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) -> SubscriberObjectiveC? {
-        guard let connection = connection
-        else {
-            let error = ErrorInformation(type: .incompleteConfiguration(missingProperty: "ConnectionConfiguration", forBuilderOption: "connection"))
-            onError(error)
-            return nil
-        }
-
-        guard let logConfiguration = logConfiguration
-        else {
-            let error = ErrorInformation(type: .incompleteConfiguration(missingProperty: "LogConfiguration", forBuilderOption: "log"))
-            onError(error)
-            return nil
-        }
-
-        guard let trackingId = trackingId
-        else {
-            let error = ErrorInformation(type: .incompleteConfiguration(missingProperty: "TrackingId", forBuilderOption: "trackingId"))
-            onError(error)
-            return nil
-        }
-
-        let subscriber = DefaultSubscriber(logConfiguration: logConfiguration,
-                                           ablyService: DefaultAblySubscriberService(configuration: connection,
-                                                                              trackingId: trackingId,
-                                                                              resolution: resolution))
-        
-        subscriber.delegate = nil
-        subscriber.delegateObjectiveC = delegateObjectiveC
-        subscriber.start(onSuccess: onSuccess, onError: onError)
-        return subscriber
-    }
-    
-    func connection(_ configuration: ConnectionConfiguration) -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder(connection: configuration,
-                                        logConfiguration: logConfiguration,
-                                        trackingId: trackingId,
-                                        resolution: resolution,
-                                        delegate: nil,
-                                        delegateObjectiveC: delegateObjectiveC)
-    }
-    
-    func trackingId(_ trackingId: String) -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder(connection: connection,
-                                        logConfiguration: logConfiguration,
-                                        trackingId: trackingId,
-                                        resolution: resolution,
-                                        delegate: nil,
-                                        delegateObjectiveC: delegateObjectiveC)
-    }
-    
-    func resolution(_ resolution: Resolution) -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder(connection: connection,
-                                        logConfiguration: logConfiguration,
-                                        trackingId: trackingId,
-                                        resolution: resolution,
-                                        delegate: nil,
-                                        delegateObjectiveC: delegateObjectiveC)
-    }
-    
-    func delegate(_ delegate: SubscriberDelegateObjectiveC) -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder(connection: connection,
-                                        logConfiguration: logConfiguration,
-                                        trackingId: trackingId,
-                                        resolution: resolution,
-                                        delegate: nil,
-                                        delegateObjectiveC: delegate)
-    }
-    
-    func log(_ configuration: LogConfiguration) -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder(connection: connection,
-                                        logConfiguration: configuration,
-                                        trackingId: trackingId,
-                                        resolution: resolution,
-                                        delegate: nil,
-                                        delegateObjectiveC: delegateObjectiveC)
+                                        delegate: delegate)
     }
 }

--- a/Sources/AblyAssetTrackingSubscriber/Services/AblySubscriberService.swift
+++ b/Sources/AblyAssetTrackingSubscriber/Services/AblySubscriberService.swift
@@ -4,7 +4,7 @@ import AblyAssetTrackingCore
 protocol AblySubscriberService: AnyObject {
     var delegate: AblySubscriberServiceDelegate? { get set }
     
-    func start(completion: @escaping ResultHandler<Void>)
-    func stop(completion: @escaping ResultHandler<Void>)
-    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler<Void>)
+    func start(completion: @escaping ResultHandler/*Void*/)
+    func stop(completion: @escaping ResultHandler/*Void*/)
+    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler/*Void*/)
 }

--- a/Sources/AblyAssetTrackingSubscriber/Services/DefaultAblySubscriberService.swift
+++ b/Sources/AblyAssetTrackingSubscriber/Services/DefaultAblySubscriberService.swift
@@ -30,7 +30,7 @@ class DefaultAblySubscriberService: AblySubscriberService {
         setup()
     }
 
-    func start(completion: @escaping ResultHandler<Void>) {
+    func start(completion: @escaping ResultHandler/*Void*/) {
         // Trigger offline event at start
         delegate?.subscriberService(sender: self, didChangeChannelConnectionStatus: .offline)
         channel.presence.subscribe({ [weak self] message in
@@ -63,13 +63,13 @@ class DefaultAblySubscriberService: AblySubscriberService {
         }
     }
 
-    func stop(completion: @escaping ResultHandler<Void>) {
+    func stop(completion: @escaping ResultHandler/*Void*/) {
         channel.unsubscribe()
         leaveChannelPresence(completion: completion)
         client.close()
     }
 
-    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler<Void>) {
+    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler/*Void*/) {
         logger.debug("Changing resolution to: \(String(describing: resolution))", source: "AblySubscriberService")
         presenceData = PresenceData(type: presenceData.type, resolution: resolution)
 
@@ -143,7 +143,7 @@ class DefaultAblySubscriberService: AblySubscriberService {
         delegate?.subscriberService(sender: self, didChangeChannelConnectionStatus: presence.toConnectionState())
     }
 
-    private func leaveChannelPresence(completion: @escaping ResultHandler<Void>) {
+    private func leaveChannelPresence(completion: @escaping ResultHandler/*Void*/) {
         channel.presence.unsubscribe()
         delegate?.subscriberService(sender: self, didChangeChannelConnectionStatus: .offline)
         

--- a/Sources/AblyAssetTrackingSubscriber/Subscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/Subscriber.swift
@@ -3,42 +3,9 @@ import Foundation
 import AblyAssetTrackingCore
 
 /**
- Main `SubscriberObjectiveC` interface implemented in SDK by `DefaultSubscriber`
- */
-@objc(Subscriber)
-public protocol SubscriberObjectiveC {
-    /**
-     Delegate object to receive events from `SubscriberObjectiveC`.
-     It maintains a weak reference to your delegate, so ensure to maintain your own strong reference as well.
-     */
-    @objc var delegateObjectiveC: SubscriberDelegateObjectiveC? { get set }
-    
-    /**
-     Sends the desired resolution for updates, to be requested from the remote publisher.
-     An initial resolution may be defined from the outset of a `SubscriberObjectiveC`'s lifespan by using the `resolution` `Builder.resolution` method on the `Builder` instance used to `start` `Builder.start` it.
-     Requests sent using this method will take time to propagate back to the publisher.
-     The `onSuccess` callback will be called once the request has been successfully registered with the server,
-     however this does not necessarily mean that the request has been received and actioned by the publisher.
-
-     - Parameters:
-        - resolution: The resolution to request, or `null` to indicate that this subscriber should explicitly indicate that it has no preference in respect of resolution.
-        - completion: Called on completion of the `sendChangeRequest` method. Ends with:
-            - `onSuccess` if the request was successfully registered with the server.
-            - `onError` if the request could not be sent or it was not possible to confirm that the server had processed the request.
-     */
-    @objc
-    func resolutionPreference(resolution: Resolution?, onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-    
-    /**
-     Stops asset subscriber from listening for asset location
-     */
-    @objc
-    func stop(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
-}
-
-/**
  Main `Subscriber` interface implemented in SDK by `DefaultSubscriber`
  */
+@objc
 public protocol Subscriber {
     /**
      Delegate object to receive events from `Subscriber`.
@@ -59,10 +26,10 @@ public protocol Subscriber {
             - `success` if the request was successfully registered with the server.
             - `failure` if the request could not be sent or it was not possible to confirm that the server had processed the request.
      */
-    func resolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler<Void>)
+    func resolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler/*Void*/)
 
     /**
      Stops asset subscriber from listening for asset location
      */
-    func stop(completion: @escaping ResultHandler<Void>)
+    func stop(completion: @escaping ResultHandler/*Void*/)
 }

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberBuilder.swift
@@ -2,64 +2,17 @@ import UIKit
 import Foundation
 import AblyAssetTrackingCore
 
-@objc(SubscriberBuilder)
-public protocol SubscriberBuilderObjectiveC: AnyObject {
-    /**
-     Creates a `SubscriberObjectiveC` which is already listening and passing location updates of asset with given `trackingId`.
-     - throws: `AssetTrackingError.incompleteConfiguration`  in case of missing mandatory property
-     - Returns: `AssetTrackingSubscriber` with passed all configuration properties.
-     */
-    @objc
-    func start(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) -> SubscriberObjectiveC?
-    
-    /**
-     Sets the mandatory `ConnectionConfiguration` property
-     */
-    @objc
-    func connection(_ configuration: ConnectionConfiguration) -> SubscriberBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `LogConfiguration` property
-     */
-    @objc
-    func log(_ configuration: LogConfiguration) -> SubscriberBuilderObjectiveC
-    
-    /**
-     Sets the mandatory `trackingId` property
-     */
-    @objc
-    func trackingId(_ trackingId: String) -> SubscriberBuilderObjectiveC
-    
-    // MARK: Optional properties
-
-    /**
-     Sets the optional `resolution` property
-
-     - Parameters:
-        - resolution: An indication of how often to this subscriber would like the publisher to sample locations, at what level of positional accuracy, and how often to send them back.
-     - Returns: A new instance of the builder with this property changed.
-     */
-    @objc
-    func resolution(_ resolution: Resolution) -> SubscriberBuilderObjectiveC
-    
-    /**
-     Sets the optional `DelegateObjectiveC` property.
-     It's optional to pass it via builder, as it can be set directly on `Subscriber`.  Maintains weak reference.
-     */
-    @objc
-    func delegate(_ delegate: SubscriberDelegateObjectiveC) -> SubscriberBuilderObjectiveC
-}
-
 /**
  Default and preferred way to create the `Subscriber`
  */
+@objc
 public protocol SubscriberBuilder {
     /**
      Creates a `Subscriber` which is already listening and passing location updates of asset with given `trackingId`.
      - throws: `AssetTrackingError.incompleteConfiguration`  in case of missing mandatory property
      - Returns: `AssetTrackingSubscriber` with passed all configuration properties.
      */
-    func start(completion: @escaping ResultHandler<Void>) -> Subscriber?
+    func start(completion: @escaping ResultHandler/*Void*/) -> Subscriber?
 
     /**
      Sets the mandatory `ConnectionConfiguration` property

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
@@ -2,39 +2,7 @@ import CoreLocation
 import Foundation
 import AblyAssetTrackingCore
 
-@objc(SubscriberDelegate)
-public protocol SubscriberDelegateObjectiveC: AnyObject {
-    /**
-     Called when `SubscriberObjectiveC` spot any (location, network or permissions) error
-     
-     - Parameters:
-        - sender: `SubscriberObjectiveC` instance.
-        - error: Detected error.
-     */
-    @objc
-    func subscriber(sender: SubscriberObjectiveC, didFailWithError error: ErrorInformation)
-    
-    /**
-     Called when the `SubscriberObjectiveC` receive any Enhanced Location (matched to road) update for observed trackable
-     
-     - Parameters:
-        - sender: `SubscriberObjectiveC` instance.
-        - location: Received location.
-     */
-    @objc
-    func subscriber(sender: SubscriberObjectiveC, didUpdateEnhancedLocation location: CLLocation)
-    
-    /**
-     Called when `SubscriberObjectiveC` change connection status
-     
-     -  Parameters:
-        - sender: `SubscriberObjectiveC` instance.
-        - status: Updated connection status.
-     */
-    @objc
-    func subscriber(sender: SubscriberObjectiveC, didChangeAssetConnectionStatus status: ConnectionState)
-}
-
+@objc
 public protocol SubscriberDelegate: AnyObject {
     /**
      Called when `Subscriber` spot any (location, network or permissions) error

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberEvent.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberEvent.swift
@@ -5,16 +5,16 @@ import AblyAssetTrackingInternal
 protocol SubscriberEvent {}
 
 struct StartEvent: SubscriberEvent {
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct StopEvent: SubscriberEvent {
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct ChangeResolutionEvent: SubscriberEvent {
     let resolution: Resolution?
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct PresenceUpdateEvent: SubscriberEvent {
@@ -22,7 +22,7 @@ struct PresenceUpdateEvent: SubscriberEvent {
 }
 
 struct AblyConnectionClosedEvent: SubscriberEvent {
-    let resultHandler: ResultHandler<Void>
+    let resultHandler: ResultHandler/*Void*/
 }
 
 struct AblyClientConnectionStateChangedEvent: SubscriberEvent {

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberFactory.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberFactory.swift
@@ -1,26 +1,16 @@
 import Foundation
 import AblyAssetTrackingCore
 
-@objc(SubscriberFactory)
-public class SubscriberFactoryObjectiveC: NSObject {
-    /**
-     Returns the default state of the`SubscriberBuilderObjectiveC`, which is incapable of starting of  `SubscriberObjectiveC`
-     instances until it has been configured fully.
-     */
-    @objc
-    public static func subscribers() -> SubscriberBuilderObjectiveC {
-        return DefaultSubscriberBuilder()
-    }
-}
-
 /**
  Factory class used only to get `SubscriberBuilder`
  */
-public class SubscriberFactory {
+@objc
+public class SubscriberFactory: NSObject {
     /**
      Returns the default state of the `SubscriberBuilder`, which is incapable of starting of  `Subscriber`
      instances until it has been configured fully.
      */
+    @objc
     public static func subscribers() -> SubscriberBuilder {
         return DefaultSubscriberBuilder()
     }

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -62,7 +62,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -101,7 +101,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable with given destination
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -122,7 +122,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -134,7 +134,7 @@ class DefaultPublisherTests: XCTestCase {
         
         // And tracking it once again
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -156,7 +156,7 @@ class DefaultPublisherTests: XCTestCase {
             let trackable = Trackable(id: "\(trackableIndex)")
             
             publisher.track(trackable: trackable) { result in
-                switch result {
+                switch result.enumUnwrap {
                 case .success:
                     expectation.fulfill()
                 case .failure:
@@ -177,7 +177,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable and receive error response from AblyPublisherService
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -196,7 +196,7 @@ class DefaultPublisherTests: XCTestCase {
         // Both `onSuccess` and `onError` callbacks should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -209,7 +209,7 @@ class DefaultPublisherTests: XCTestCase {
         
         expectation = XCTestExpectation()
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -228,7 +228,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When adding a trackable
         publisher.add(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -262,7 +262,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -271,7 +271,7 @@ class DefaultPublisherTests: XCTestCase {
         }
         // And then adding another trackable
         publisher.add(trackable: Trackable(id: "TestAddedTrackableId1")) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -291,7 +291,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When adding a trackable and receive error response from AblyPublisherService
         publisher.add(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -310,7 +310,7 @@ class DefaultPublisherTests: XCTestCase {
         // `onSuccess` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.add(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -330,7 +330,7 @@ class DefaultPublisherTests: XCTestCase {
         // `onError` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.add(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -355,7 +355,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable
         publisher.remove(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap(Bool.self) {
             case .success(let present):
                 receivedWasPresent = present
                 expectation.fulfill()
@@ -392,7 +392,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable which was tracked before (so it's set as the activeTrackable)
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -405,7 +405,7 @@ class DefaultPublisherTests: XCTestCase {
 
         expectation = XCTestExpectation(description: "Handler for `remove` call")
         publisher.remove(trackable: publisher.activeTrackable!) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -438,7 +438,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable which was no tracked before (so it's NOT set as the activeTrackable)
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -451,7 +451,7 @@ class DefaultPublisherTests: XCTestCase {
         expectation = XCTestExpectation(description: "Handler for `remove` call")
         let removedTrackable = Trackable(id: "AnotherTrackableId")
         publisher.remove(trackable: removedTrackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -478,7 +478,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable and receive error from AblyPublisherService
         publisher.remove(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let receivedError):
@@ -498,7 +498,7 @@ class DefaultPublisherTests: XCTestCase {
         // When removing trackable `onSuccess` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.remove(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -519,7 +519,7 @@ class DefaultPublisherTests: XCTestCase {
         // When removing trackable `onError` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.remove(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -537,7 +537,7 @@ class DefaultPublisherTests: XCTestCase {
     func testChangeRoutingProfile_called() {
         // Given: Default RoutingProfile set to .driving
         publisher.changeRoutingProfile(profile: .cycling) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
                 XCTAssertEqual(self.routeProvider.changeRoutingProfileParamRoutingProfile, .cycling)
@@ -552,7 +552,7 @@ class DefaultPublisherTests: XCTestCase {
         let expectedDestination = CLLocationCoordinate2D(latitude: 3.1415, longitude: 2.7182)
         
         publisher.changeRoutingProfile(profile: .cycling) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
                 XCTAssertTrue(self.routeProvider.getRouteCalled)
@@ -586,7 +586,7 @@ class DefaultPublisherTests: XCTestCase {
         }
         
         ablyService.close { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -838,7 +838,7 @@ class DefaultPublisherTests: XCTestCase {
         
         let publisherStopExpectation = self.expectation(description: "Publisher stop expectation")
         publisher.stop { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success: ()
             case .failure(let error):
                 XCTFail("Publisher stop failed with error: \(error)")
@@ -850,7 +850,7 @@ class DefaultPublisherTests: XCTestCase {
         
         let trackAfterStopCompletionExpectation = self.expectation(description: "Track after stop event completion expectation")
         publisher.track(trackable: trackable) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Track success shouldn't occur when publisher is stopped")
             case .failure: ()

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -62,7 +62,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -101,7 +101,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable with given destination
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -122,7 +122,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -134,7 +134,7 @@ class DefaultPublisherTests: XCTestCase {
         
         // And tracking it once again
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -156,7 +156,7 @@ class DefaultPublisherTests: XCTestCase {
             let trackable = Trackable(id: "\(trackableIndex)")
             
             publisher.track(trackable: trackable) { result in
-                switch result.enumUnwrap {
+                switch result.unwrap {
                 case .success:
                     expectation.fulfill()
                 case .failure:
@@ -177,7 +177,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable and receive error response from AblyPublisherService
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -196,7 +196,7 @@ class DefaultPublisherTests: XCTestCase {
         // Both `onSuccess` and `onError` callbacks should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -209,7 +209,7 @@ class DefaultPublisherTests: XCTestCase {
         
         expectation = XCTestExpectation()
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -228,7 +228,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When adding a trackable
         publisher.add(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -262,7 +262,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When tracking a trackable
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -271,7 +271,7 @@ class DefaultPublisherTests: XCTestCase {
         }
         // And then adding another trackable
         publisher.add(trackable: Trackable(id: "TestAddedTrackableId1")) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -291,7 +291,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When adding a trackable and receive error response from AblyPublisherService
         publisher.add(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let error):
@@ -310,7 +310,7 @@ class DefaultPublisherTests: XCTestCase {
         // `onSuccess` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.add(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -330,7 +330,7 @@ class DefaultPublisherTests: XCTestCase {
         // `onError` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.add(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -355,7 +355,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable
         publisher.remove(trackable: trackable) { result in
-            switch result.enumUnwrap(Bool.self) {
+            switch result.unwrap(Bool.self) {
             case .success(let present):
                 receivedWasPresent = present
                 expectation.fulfill()
@@ -392,7 +392,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable which was tracked before (so it's set as the activeTrackable)
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -405,7 +405,7 @@ class DefaultPublisherTests: XCTestCase {
 
         expectation = XCTestExpectation(description: "Handler for `remove` call")
         publisher.remove(trackable: publisher.activeTrackable!) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -438,7 +438,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable which was no tracked before (so it's NOT set as the activeTrackable)
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -451,7 +451,7 @@ class DefaultPublisherTests: XCTestCase {
         expectation = XCTestExpectation(description: "Handler for `remove` call")
         let removedTrackable = Trackable(id: "AnotherTrackableId")
         publisher.remove(trackable: removedTrackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 expectation.fulfill()
             case .failure:
@@ -478,7 +478,7 @@ class DefaultPublisherTests: XCTestCase {
 
         // When removing trackable and receive error from AblyPublisherService
         publisher.remove(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure(let receivedError):
@@ -498,7 +498,7 @@ class DefaultPublisherTests: XCTestCase {
         // When removing trackable `onSuccess` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.remove(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
                 expectation.fulfill()
@@ -519,7 +519,7 @@ class DefaultPublisherTests: XCTestCase {
         // When removing trackable `onError` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
         publisher.remove(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success callback shouldn't be called")
             case .failure:
@@ -537,7 +537,7 @@ class DefaultPublisherTests: XCTestCase {
     func testChangeRoutingProfile_called() {
         // Given: Default RoutingProfile set to .driving
         publisher.changeRoutingProfile(profile: .cycling) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
                 XCTAssertEqual(self.routeProvider.changeRoutingProfileParamRoutingProfile, .cycling)
@@ -552,7 +552,7 @@ class DefaultPublisherTests: XCTestCase {
         let expectedDestination = CLLocationCoordinate2D(latitude: 3.1415, longitude: 2.7182)
         
         publisher.changeRoutingProfile(profile: .cycling) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
                 XCTAssertTrue(self.routeProvider.getRouteCalled)
@@ -586,7 +586,7 @@ class DefaultPublisherTests: XCTestCase {
         }
         
         ablyService.close { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -838,7 +838,7 @@ class DefaultPublisherTests: XCTestCase {
         
         let publisherStopExpectation = self.expectation(description: "Publisher stop expectation")
         publisher.stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success: ()
             case .failure(let error):
                 XCTFail("Publisher stop failed with error: \(error)")
@@ -850,7 +850,7 @@ class DefaultPublisherTests: XCTestCase {
         
         let trackAfterStopCompletionExpectation = self.expectation(description: "Track after stop event completion expectation")
         publisher.track(trackable: trackable) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Track success shouldn't occur when publisher is stopped")
             case .failure: ()

--- a/Tests/PublisherTests/Mocks/MockAblyPublisherService.swift
+++ b/Tests/PublisherTests/Mocks/MockAblyPublisherService.swift
@@ -6,9 +6,9 @@ import AblyAssetTrackingCore
 class MockAblyPublisherService: AblyPublisherService {
     var trackCalled: Bool = false
     var trackParamTrackable: Trackable?
-    var trackParamResultHandler: ResultHandler<Void>?
-    var trackCompletionHandler: ((ResultHandler<Void>?) -> Void)?
-    func track(trackable: Trackable, completion: ResultHandler<Void>?) {
+    var trackParamResultHandler: ResultHandler?/*Void*/
+    var trackCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
+    func track(trackable: Trackable, completion: ResultHandler?/*Void*/) {
         trackCalled = true
         trackParamTrackable = trackable
         trackParamResultHandler = completion
@@ -17,9 +17,9 @@ class MockAblyPublisherService: AblyPublisherService {
     
     var stopTrackingCalled: Bool = false
     var stopTrackingParamTrackable: Trackable?
-    var stopTrackingParamResultHandler: ResultHandler<Bool>?
-    var stopTrackingResultCompletionHandler: ((ResultHandler<Bool>?) -> Void)?
-    func stopTracking(trackable: Trackable, completion: ResultHandler<Bool>?) {
+    var stopTrackingParamResultHandler: ResultHandler?/*Bool*/
+    var stopTrackingResultCompletionHandler: ((ResultHandler?/*Bool*/) -> Void)?
+    func stopTracking(trackable: Trackable, completion: ResultHandler?/*Bool*/) {
         stopTrackingCalled = true
         stopTrackingParamTrackable = trackable
         stopTrackingParamResultHandler = completion
@@ -35,9 +35,9 @@ class MockAblyPublisherService: AblyPublisherService {
     var sendEnhancedAssetLocationUpdateCalled: Bool = false
     var sendEnhancedAssetLocationUpdateParamLocationUpdate: EnhancedLocationUpdate?
     var sendEnhancedAssetLocationUpdateParamTrackable: Trackable?
-    var sendEnhancedAssetLocationUpdateParamCompletion: ResultHandler<Void>?
-    var sendEnhancedAssetLocationUpdateParamCompletionHandler: ((ResultHandler<Void>?) -> Void)?
-    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler<Void>?) {
+    var sendEnhancedAssetLocationUpdateParamCompletion: ResultHandler?/*Void*/
+    var sendEnhancedAssetLocationUpdateParamCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
+    func sendEnhancedAssetLocationUpdate(locationUpdate: EnhancedLocationUpdate, forTrackable trackable: Trackable, completion: ResultHandler?/*Void*/) {
         sendEnhancedAssetLocationUpdateCounter += 1
         sendEnhancedAssetLocationUpdateCalled = true
         sendEnhancedAssetLocationUpdateParamLocationUpdate = locationUpdate
@@ -48,9 +48,9 @@ class MockAblyPublisherService: AblyPublisherService {
     
     
     var closeCalled: Bool = false
-    var closeParamCompletion: ResultHandler<Void>?
-    var closeResultCompletionHandler: ((ResultHandler<Void>?) -> Void)?
-    func close(completion: @escaping ResultHandler<Void>) {
+    var closeParamCompletion: ResultHandler?/*Void*/
+    var closeResultCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
+    func close(completion: @escaping ResultHandler/*Void*/) {
         closeCalled = true
         closeParamCompletion = completion
         closeResultCompletionHandler?(completion)

--- a/Tests/PublisherTests/Mocks/MockRouteProvider.swift
+++ b/Tests/PublisherTests/Mocks/MockRouteProvider.swift
@@ -7,8 +7,8 @@ class MockRouteProvider: RouteProvider{
     var getRouteCalled: Bool = false
     var getRouteParamDestination: CLLocationCoordinate2D?
     var getRouteParamRoutingProfile: RoutingProfile?
-    var getRouteParamResultHandler: ResultHandler<Route>?
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    var getRouteParamResultHandler: ResultHandler?/*Route*/
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
         getRouteCalled = true
         getRouteParamDestination = destination
         getRouteParamRoutingProfile = routingProfile
@@ -17,8 +17,8 @@ class MockRouteProvider: RouteProvider{
     
     var changeRoutingProfileCalled: Bool = false
     var changeRoutingProfileParamRoutingProfile: RoutingProfile?
-    var changeRoutingProfileParamResultHandler: ResultHandler<Route>?
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    var changeRoutingProfileParamResultHandler: ResultHandler?/*Route*/
+    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
         changeRoutingProfileCalled = true
         changeRoutingProfileParamRoutingProfile = routingProfile
         changeRoutingProfileParamResultHandler = completion

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -38,7 +38,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.stop { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 isSuccess.toggle()
             case .failure:
@@ -63,7 +63,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.stop { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -96,7 +96,7 @@ class DefaultSubscriberTests: XCTestCase {
         expectation = XCTestExpectation()
         
         subscriber.stop { result in
-            switch result {
+            switch result.enumUnwrap {
             case .failure:
                 XCTFail("Error not expected.")
             case .success:
@@ -128,7 +128,7 @@ class DefaultSubscriberTests: XCTestCase {
         expectation = XCTestExpectation()
         
         subscriber.resolutionPreference(resolution: nil) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -192,7 +192,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.resolutionPreference(resolution: resolution) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 isSuccess.toggle()
                 expectation.fulfill()
@@ -218,7 +218,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.resolutionPreference(resolution: resolution) { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success not expected")
             case .failure(let error):
@@ -260,7 +260,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.start { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 isSuccess.toggle()
             case .failure:
@@ -285,7 +285,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.start { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -38,7 +38,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 isSuccess.toggle()
             case .failure:
@@ -63,7 +63,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -96,7 +96,7 @@ class DefaultSubscriberTests: XCTestCase {
         expectation = XCTestExpectation()
         
         subscriber.stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .failure:
                 XCTFail("Error not expected.")
             case .success:
@@ -128,7 +128,7 @@ class DefaultSubscriberTests: XCTestCase {
         expectation = XCTestExpectation()
         
         subscriber.resolutionPreference(resolution: nil) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):
@@ -192,7 +192,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.resolutionPreference(resolution: resolution) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 isSuccess.toggle()
                 expectation.fulfill()
@@ -218,7 +218,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.resolutionPreference(resolution: resolution) { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success not expected")
             case .failure(let error):
@@ -260,7 +260,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.start { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 isSuccess.toggle()
             case .failure:
@@ -285,7 +285,7 @@ class DefaultSubscriberTests: XCTestCase {
         
         // When
         subscriber.start { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 XCTFail("Success not expected.")
             case .failure(let error):

--- a/Tests/SubscriberTests/Mocks/MockAblySubscriberService.swift
+++ b/Tests/SubscriberTests/Mocks/MockAblySubscriberService.swift
@@ -8,20 +8,20 @@ class MockAblySubscriberService: AblySubscriberService {
         didSet { wasDelegateSet = true }
     }
     
-    var startCompletionHandler: ((ResultHandler<Void>?) -> Void)?
-    var startResultHandler: ResultHandler<Void>?
+    var startCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
+    var startResultHandler: ResultHandler?/*Void*/
     var startWasCalled: Bool = false
-    func start(completion: @escaping ResultHandler<Void>) {
+    func start(completion: @escaping ResultHandler/*Void*/) {
         startWasCalled = true
         startResultHandler = completion
         
         startCompletionHandler?(completion)
     }
     
-    var stopResultHandler: ResultHandler<Void>?
-    var stopCompletionHandler: ((ResultHandler<Void>?) -> Void)?
+    var stopResultHandler: ResultHandler?/*Void*/
+    var stopCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
     var stopWasCalled: Bool = false
-    func stop(completion: @escaping ResultHandler<Void>) {
+    func stop(completion: @escaping ResultHandler/*Void*/) {
         stopWasCalled = true
         stopResultHandler = completion
         
@@ -30,9 +30,9 @@ class MockAblySubscriberService: AblySubscriberService {
     
     var sendResolutionPreferenceWasCalled: Bool = false
     var sendResolutionPreferenceResolutionParam: Resolution?
-    var sendResolutionPreferenceResultHander: ResultHandler<Void>?
-    var sendResolutionPreferenceCompletionHandler: ((ResultHandler<Void>?) -> Void)?
-    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler<Void>) {
+    var sendResolutionPreferenceResultHander: ResultHandler?/*Void*/
+    var sendResolutionPreferenceCompletionHandler: ((ResultHandler?/*Void*/) -> Void)?
+    func sendResolutionPreference(resolution: Resolution?, completion: @escaping ResultHandler/*Void*/) {
         sendResolutionPreferenceWasCalled = true
         sendResolutionPreferenceResolutionParam = resolution
         sendResolutionPreferenceResultHander = completion

--- a/Tests/SystemTests/Mocks/MockRouteProvider.swift
+++ b/Tests/SystemTests/Mocks/MockRouteProvider.swift
@@ -7,8 +7,8 @@ class MockRouteProvider: RouteProvider{
     var getRouteCalled: Bool = false
     var getRouteParamDestination: CLLocationCoordinate2D?
     var getRouteParamRoutingProfile: RoutingProfile?
-    var getRouteParamResultHandler: ResultHandler<Route>?
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    var getRouteParamResultHandler: ResultHandler?/*Route*/
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
         getRouteCalled = true
         getRouteParamDestination = destination
         getRouteParamRoutingProfile = routingProfile
@@ -17,8 +17,8 @@ class MockRouteProvider: RouteProvider{
     
     var changeRoutingProfileCalled: Bool = false
     var changeRoutingProfileParamRoutingProfile: RoutingProfile?
-    var changeRoutingProfileParamResultHandler: ResultHandler<Route>?
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    var changeRoutingProfileParamResultHandler: ResultHandler?/*Route*/
+    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler/*Route*/) {
         changeRoutingProfileCalled = true
         changeRoutingProfileParamRoutingProfile = routingProfile
         changeRoutingProfileParamResultHandler = completion

--- a/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
@@ -161,7 +161,7 @@ class PublisherAuthenticationSystemTests: XCTestCase {
 
         let stopExpectation = self.expectation(description: "Publisher stops")
         publisher.stop { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success:
                 stopExpectation.fulfill()
             case .failure(let error):

--- a/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
@@ -161,7 +161,7 @@ class PublisherAuthenticationSystemTests: XCTestCase {
 
         let stopExpectation = self.expectation(description: "Publisher stops")
         publisher.stop { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success:
                 stopExpectation.fulfill()
             case .failure(let error):

--- a/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
@@ -125,7 +125,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
             .trackingId("Trackable ID")
             .log(logConfiguration)
             .start { result in
-                switch result.enumUnwrap {
+                switch result.unwrap {
                 case .success: ()
                 case .failure(let error):
                     XCTFail("Subscriber start failed with error: \(error)")
@@ -137,7 +137,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         let resolutionCompletionExpectation = self.expectation(description: "Resolution completion expectation")
         resolution = Resolution(accuracy: .balanced, desiredInterval: 1000, minimumDisplacement: 100)
         subscriber?.resolutionPreference(resolution: resolution, completion: { result in
-            switch result.enumUnwrap {
+            switch result.unwrap {
             case .success: ()
             case .failure(let error):
                 XCTFail("Resolution completion failed with error: \(error)")

--- a/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
@@ -125,7 +125,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
             .trackingId("Trackable ID")
             .log(logConfiguration)
             .start { result in
-                switch result {
+                switch result.enumUnwrap {
                 case .success: ()
                 case .failure(let error):
                     XCTFail("Subscriber start failed with error: \(error)")
@@ -137,7 +137,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         let resolutionCompletionExpectation = self.expectation(description: "Resolution completion expectation")
         resolution = Resolution(accuracy: .balanced, desiredInterval: 1000, minimumDisplacement: 100)
         subscriber?.resolutionPreference(resolution: resolution, completion: { result in
-            switch result {
+            switch result.enumUnwrap {
             case .success: ()
             case .failure(let error):
                 XCTFail("Resolution completion failed with error: \(error)")


### PR DESCRIPTION
## Why?

The Current version of "Ably Asset Tracking SDK" has two layers to communicate with swift and objective-c.
The differences between them are slight: 

- the inability to use `Swift Result<T,U>` in objective-c
- the inability to use `Swift enums` in objective-c

Using these layers impose code duplication, which in turn could generate potential bugs, e.g.:
https://github.com/ably/ably-asset-tracking-swift/blob/0885a04f729964d3b396a0f5e735b7ae128b2ef6/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift#L237-L257

## Solution

I replaced the Swift `Result<T,U>` type with a custom [ATResult](https://github.com/ably/ably-asset-tracking-swift/blob/f6bc65b6cdbf58990530d5d6153fc469587ee2e8/Sources/AblyAssetTrackingCore/ResultHandler.swift) class that can be used in both languages with ease.
I also added a helper for `ATResult` that can unwrap its properties to enums, and because of that, the Swift code refactoring goes easier.
https://github.com/ably/ably-asset-tracking-swift/blob/f6bc65b6cdbf58990530d5d6153fc469587ee2e8/Sources/AblyAssetTrackingCore/ResultHandler.swift#L41-L68

## Usage of `ATResult` Swift helper

- When `ATResult` `success` property has no value, you can use `enumUnwrap` static var directly on the `ATResult` instance
https://github.com/ably/ably-asset-tracking-swift/blob/f6bc65b6cdbf58990530d5d6153fc469587ee2e8/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift#L499-L506

- When `ATResult` `success` property has some value, you can use the `enumUnwrap(T)` method directly on the `ATResult`, where `T` is an expected type of value/object wrapped by `success(T)` case:
https://github.com/ably/ably-asset-tracking-swift/blob/f6bc65b6cdbf58990530d5d6153fc469587ee2e8/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift#L272-L282

#### I decided to use the result wrapped in an object instead of using the `success:error:` block because:

- it's much easier to refactor the whole Swift code
- it's similar to the Swift `Result<T,U>` type

_This solution is not ideal, but it's a win-win for both platforms_