### PR TITLE
AWS action for OIDC

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,13 @@ jobs:
           ./jazzy/build.sh
           ls -al docs
 
+      - name: Configure AWS Credentials
+      - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: eu-west-2
+        role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-builds-ably-asset-tracking-swift
+        role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
+
       - uses: ably/sdk-upload-action@v1
         with:
           sourcePath: docs


### PR DESCRIPTION
Add AWS credentials actions for OIDC and remove S3 access key

Closes https://github.com/ably/ably-asset-tracking-swift/issues/295