### PR TITLE
If we fail to enter presence due to token capabilities, fetch new token and retry

### DIFF
--- a/.sourcery-InternalTests.yml
+++ b/.sourcery-InternalTests.yml
@@ -1,0 +1,6 @@
+sources:
+  - Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+templates:
+  - Sourcery/templates/AblySDKMocks.stencil
+output:
+  Tests/InternalTests/Mocks/AblySDKMocks.swift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,9 @@ and then manually merge the delta contents in to the main change log (where `v1.
 - SwiftLint is integrated into the project. Make sure that your code does not add any SwiftLint related warning.
 - Please remove default Xcode header comments (with author, license and creation date) as they're not necessary.
 - If you're adding or modifying any part of the public interface of SDK, please also update [QuickHelp](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/SymbolDocumentation.html#//apple_ref/doc/uid/TP40016497-CH51-SW1) documentation.
+
+## Generating mocks
+
+We use [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to generate mocks for the protocols in the file `Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift`. At the time of writing, there is no way to automatically generate these mocks as part of the SPM build process, so when you update this file you’ll need to manually run the command `mint run krzysztofzablocki/Sourcery@1.8.2 --config .sourcery-InternalTests.yml`. (Here I’ve used [Mint](https://github.com/yonaskolb/Mint) to run Sourcery; other options are available but Mint allows us to make sure we’re all running the same version of Sourcery.)
+
+When [Swift package plugins](https://developer.apple.com/videos/play/wwdc2022/110359/) get introduced in Swift 5.6, we might be able to generate these mocks automatically.

--- a/Sourcery/templates/AblySDKMocks.stencil
+++ b/Sourcery/templates/AblySDKMocks.stencil
@@ -1,0 +1,137 @@
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
+
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
+{% for import in argument.autoMockableImports %}
+import {{ import }}
+{% endfor %}
+
+{% for import in argument.autoMockableTestableImports %}
+@testable import {{ import }}
+{% endfor %}
+
+{% macro swiftifyMethodName name %}{{ name | replace:"(","_" | replace:")","" | replace:":","_" | replace:"`","" | snakeToCamelCase | lowerFirstWord }}{% endmacro %}
+
+{% macro methodThrowableErrorDeclaration method %}
+    var {% call swiftifyMethodName method.selectorName %}ThrowableError: Error?
+{% endmacro %}
+
+{% macro methodThrowableErrorUsage method %}
+        if let error = {% call swiftifyMethodName method.selectorName %}ThrowableError {
+            throw error
+        }
+{% endmacro %}
+
+{% macro methodReceivedParameters method %}
+    {%if method.parameters.count == 1 %}
+        {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {{ param.name }}{% endfor %}
+        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append({% for param in method.parameters %}{{ param.name }}){% endfor %}
+    {% else %}
+    {% if not method.parameters.count == 0 %}
+        {% call swiftifyMethodName method.selectorName %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
+        {% call swiftifyMethodName method.selectorName %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+    {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% macro methodClosureName method %}{% call swiftifyMethodName method.selectorName %}Closure{% endmacro %}
+
+{% macro closureReturnTypeName method %}{% if method.isOptionalReturnType %}{{ method.unwrappedReturnTypeName }}?{% else %}{{ method.returnTypeName }}{% endif %}{% endmacro %}
+
+{% macro methodClosureDeclaration method %}
+    var {% call methodClosureName method %}: (({% for param in method.parameters %}{{ param.typeName }}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.isAsync %}async {% endif %}{% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
+{% endmacro %}
+
+{% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+
+{% macro mockMethod method %}
+    //MARK: - {{ method.shortName }}
+
+    {% if method.throws %}
+        {% call methodThrowableErrorDeclaration method %}
+    {% endif %}
+    {% if not method.isInitializer %}
+    var {% call swiftifyMethodName method.selectorName %}CallsCount = 0
+    var {% call swiftifyMethodName method.selectorName %}Called: Bool {
+        return {% call swiftifyMethodName method.selectorName %}CallsCount > 0
+    }
+    {% endif %}
+    {% if method.parameters.count == 1 %}
+    var {% call swiftifyMethodName method.selectorName %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}?{% endfor %}
+    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}{{ param.typeName.unwrappedTypeName }}{{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% elif not method.parameters.count == 0 %}
+    var {% call swiftifyMethodName method.selectorName %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})?
+    var {% call swiftifyMethodName method.selectorName %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% endif %}
+    {% if not method.returnTypeName.isVoid and not method.isInitializer %}
+    var {% call swiftifyMethodName method.selectorName %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ method.returnTypeName }}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType }}{{ '!' if not method.isOptionalReturnType }}
+    {% endif %}
+    {% call methodClosureDeclaration method %}
+
+{% if method.isInitializer %}
+    required {{ method.name }} {
+        {% call methodReceivedParameters method %}
+        {% call methodClosureName method %}?({% call methodClosureCallParameters method %})
+    }
+{% else %}
+    {% for name, attribute in method.attributes %}
+    {% for value in attribute %}
+    {{ value }}
+    {% endfor %}
+    {% endfor %}
+    func {{ method.name }}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+        {% if method.throws %}
+        {% call methodThrowableErrorUsage method %}
+        {% endif %}
+        {% call swiftifyMethodName method.selectorName %}CallsCount += 1
+        {% call methodReceivedParameters method %}
+        {% if method.returnTypeName.isVoid %}
+        {% if method.throws %}try {% endif %}{% if method.isAsync %}await {% endif %}{% call methodClosureName method %}?({% call methodClosureCallParameters method %})
+        {% else %}
+        if let {% call methodClosureName method %} = {% call methodClosureName method %} {
+            return {{ 'try ' if method.throws }}{{ 'await ' if method.isAsync }}{% call methodClosureName method %}({% call methodClosureCallParameters method %})
+        } else {
+            return {% call swiftifyMethodName method.selectorName %}ReturnValue
+        }
+        {% endif %}
+    }
+
+{% endif %}
+{% endmacro %}
+
+{% macro mockOptionalVariable variable %}
+    var {% call mockedVariableName variable %}: {{ variable.typeName }}
+{% endmacro %}
+
+{% macro mockNonOptionalArrayOrDictionaryVariable variable %}
+    var {% call mockedVariableName variable %}: {{ variable.typeName }} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
+{% endmacro %}
+
+{% macro mockNonOptionalVariable variable %}
+    var {% call mockedVariableName variable %}: {{ variable.typeName }} {
+        get { return {% call underlyingMockedVariableName variable %} }
+        set(value) { {% call underlyingMockedVariableName variable %} = value }
+    }
+    var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}!
+{% endmacro %}
+
+{% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
+{% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
+
+{% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}{% if type.name != "AutoMockable" %}
+class {{ type.name }}Mock: {{ type.name }} {
+{% for variable in type.allVariables|!definedInExtension %}
+    {% if variable.isOptional %}{% call mockOptionalVariable variable %}{% elif variable.isArray or variable.isDictionary %}{% call mockNonOptionalArrayOrDictionaryVariable variable %}{% else %}{% call mockNonOptionalVariable variable %}{% endif %}
+{% endfor %}
+
+{% for method in type.allMethods|!definedInExtension %}
+    {% call mockMethod method %}
+{% endfor %}
+}
+{% endif %}{% endfor %}

--- a/Sourcery/templates/AblySDKMocks.stencil
+++ b/Sourcery/templates/AblySDKMocks.stencil
@@ -1,12 +1,9 @@
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
 
-import Foundation
-#if os(iOS) || os(tvOS) || os(watchOS)
-import UIKit
-#elseif os(OSX)
-import AppKit
-#endif
+import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
+import Ably
 
 {% for import in argument.autoMockableImports %}
 import {{ import }}

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyCommon.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyCommon.swift
@@ -68,16 +68,6 @@ public protocol AblyCommon {
      - Parameter completion:    The closure that will be called when `Ably` connection state will change to `closed` or `failed`.
      */
     func close(presenceData: PresenceData, completion: @escaping ResultHandler<Void>)
-    
-    /**
-     Common required initialiser
-     
-     - Parameter configuration: The `ConnectionConfiguration` object
-     - Parameter mode:          The mode in which `Ably` wrapper is initialise. Available modes: `subscribe`, `publish`
-     - Parameter logger:        The object of the `Logger` introduced in `swift-log` package
-     
-     */
-    init(configuration: ConnectionConfiguration, mode: AblyMode, logger: Logger)
 }
 
 /**

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -9,13 +9,13 @@ public class DefaultAbly: AblyCommon {
     public weak var subscriberDelegate: AblySubscriberServiceDelegate?
     
     private let logger: Logger
-    private let client: ARTRealtime
-    private let mode: AblyMode
+    private let client: AblySDKRealtime
+    let mode: AblyMode
     
-    private var channels: [String: ARTRealtimeChannel] = [:]
+    private var channels: [String: AblySDKRealtimeChannel] = [:]
 
-    public required init(configuration: ConnectionConfiguration, mode: AblyMode, logger: Logger) {
-        self.client = ARTRealtime(options: configuration.getClientOptions())
+    public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, mode: AblyMode, logger: Logger) {
+        self.client = factory.create(withConfiguration: configuration)
         self.mode = mode
         self.logger = logger
     }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
@@ -1,0 +1,112 @@
+import Ably
+import AblyAssetTrackingCore
+
+struct AblyCocoaSDKRealtime: AblySDKRealtime {
+    fileprivate let realtime: ARTRealtime
+    
+    var channels: AblySDKRealtimeChannels {
+        return AblyCocoaSDKRealtimeChannels(channels: realtime.channels)
+    }
+    
+    var connection: AblySDKConnection {
+        return AblyCocoaSDKConnection(connection: realtime.connection)
+    }
+    
+    func close() {
+        realtime.close()
+    }
+}
+
+struct AblyCocoaSDKRealtimeChannels: AblySDKRealtimeChannels {
+    fileprivate let channels: ARTRealtimeChannels
+    
+    func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions?) -> AblySDKRealtimeChannel {
+        let channel = channels.getChannelFor(trackingId: trackingId, options: options)
+        return AblyCocoaSDKRealtimeChannel(channel: channel)
+    }
+}
+
+struct AblyCocoaSDKRealtimeChannel: AblySDKRealtimeChannel {
+    fileprivate let channel: ARTRealtimeChannel
+    
+    var presence: AblySDKRealtimePresence {
+        return AblyCocoaSDKRealtimePresence(presence: channel.presence)
+    }
+    
+    func subscribe(_ name: String, callback: @escaping (ARTMessage) -> Void) -> AblySDKEventListener? {
+        if let eventListener = channel.subscribe(name, callback: callback) {
+            return AblyCocoaSDKEventListener(eventListener: eventListener)
+        } else {
+            return nil
+        }
+    }
+    
+    func unsubscribe() {
+        channel.unsubscribe()
+    }
+    
+    func detach(_ callback: ARTCallback?) {
+        channel.detach(callback)
+    }
+    
+    func on(_ callback: @escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener {
+        return AblyCocoaSDKEventListener(eventListener: channel.on(callback))
+    }
+    
+    func publish(_ messages: [ARTMessage], callback: ARTCallback?) {
+        channel.publish(messages, callback: callback)
+    }
+}
+
+struct AblyCocoaSDKRealtimePresence: AblySDKRealtimePresence {
+    fileprivate let presence: ARTRealtimePresence
+    
+    func get(_ callback: @escaping ([ARTPresenceMessage]?, ARTErrorInfo?) -> Void) {
+        presence.get(callback)
+    }
+    
+    func enter(_ data: Any?, callback: ARTCallback?) {
+        presence.enter(data, callback: callback)
+    }
+    
+    func update(_ data: Any?, callback: ARTCallback?) {
+        presence.update(data, callback: callback)
+    }
+    
+    func leave(_ data: Any?, callback: ARTCallback?) {
+        presence.leave(data, callback: callback)
+    }
+    
+    func subscribe(_ callback: @escaping (ARTPresenceMessage) -> Void) -> AblySDKEventListener? {
+        if let eventListener = presence.subscribe(callback) {
+            return AblyCocoaSDKEventListener(eventListener: eventListener)
+        } else {
+            return nil
+        }
+    }
+    
+    func unsubscribe() {
+        presence.unsubscribe()
+    }
+}
+
+struct AblyCocoaSDKConnection: AblySDKConnection {
+    fileprivate let connection: ARTConnection
+    
+    func on(_ callback: @escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener {
+        return AblyCocoaSDKEventListener(eventListener: connection.on(callback))
+    }
+}
+
+struct AblyCocoaSDKEventListener: AblySDKEventListener {
+    fileprivate let eventListener: ARTEventListener
+}
+
+public class AblyCocoaSDKRealtimeFactory: AblySDKRealtimeFactory {
+    public init() {}
+    
+    public func create(withConfiguration configuration: ConnectionConfiguration) -> AblySDKRealtime {
+        let realtime = ARTRealtime(options: configuration.getClientOptions())
+        return AblyCocoaSDKRealtime(realtime: realtime)
+    }
+}

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
@@ -12,6 +12,10 @@ struct AblyCocoaSDKRealtime: AblySDKRealtime {
         return AblyCocoaSDKConnection(connection: realtime.connection)
     }
     
+    var auth: AblySDKAuth {
+        return AblyCocoaSDKAuth(auth: realtime.auth)
+    }
+    
     func close() {
         realtime.close()
     }
@@ -56,6 +60,10 @@ struct AblyCocoaSDKRealtimeChannel: AblySDKRealtimeChannel {
     func publish(_ messages: [ARTMessage], callback: ARTCallback?) {
         channel.publish(messages, callback: callback)
     }
+    
+    func attach(_ callback: ARTCallback?) {
+        channel.attach(callback)
+    }
 }
 
 struct AblyCocoaSDKRealtimePresence: AblySDKRealtimePresence {
@@ -95,6 +103,14 @@ struct AblyCocoaSDKConnection: AblySDKConnection {
     
     func on(_ callback: @escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener {
         return AblyCocoaSDKEventListener(eventListener: connection.on(callback))
+    }
+}
+
+struct AblyCocoaSDKAuth: AblySDKAuth {
+    fileprivate let auth: ARTAuth
+    
+    func authorize(_ callback: @escaping (ARTTokenDetails?, Error?) -> Void) {
+        auth.authorize(callback)
     }
 }
 

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -1,0 +1,42 @@
+import Ably
+import AblyAssetTrackingCore
+
+public protocol AblySDKRealtimeFactory {
+    func create(withConfiguration configuration: ConnectionConfiguration) -> AblySDKRealtime
+}
+
+public protocol AblySDKRealtime {
+    var channels: AblySDKRealtimeChannels { get }
+    var connection: AblySDKConnection { get }
+    
+    func close()
+}
+
+public protocol AblySDKRealtimeChannels {
+    func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions?) -> AblySDKRealtimeChannel
+}
+
+public protocol AblySDKRealtimeChannel {
+    var presence: AblySDKRealtimePresence { get }
+    @discardableResult func subscribe(_ name: String, callback: @escaping ARTMessageCallback) -> AblySDKEventListener?
+    func unsubscribe()
+    func detach(_ callback: ARTCallback?)
+    @discardableResult func on(_ callback: @escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener
+    func publish(_ messages: [ARTMessage], callback: ARTCallback?)
+}
+
+public protocol AblySDKRealtimePresence {
+    func get(_ callback: @escaping ARTPresenceMessagesCallback)
+    func enter(_ data: Any?, callback: ARTCallback?)
+    func update(_ data: Any?, callback: ARTCallback?)
+    func leave(_ data: Any?, callback: ARTCallback?)
+    @discardableResult func subscribe(_ callback: @escaping ARTPresenceMessageCallback) -> AblySDKEventListener?
+    func unsubscribe()
+}
+
+//sourcery: AutoMockable
+public protocol AblySDKConnection {
+    @discardableResult func on(_ callback: @escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener
+}
+
+public protocol AblySDKEventListener {}

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -1,10 +1,12 @@
 import Ably
 import AblyAssetTrackingCore
 
+//sourcery: AutoMockable
 public protocol AblySDKRealtimeFactory {
     func create(withConfiguration configuration: ConnectionConfiguration) -> AblySDKRealtime
 }
 
+//sourcery: AutoMockable
 public protocol AblySDKRealtime {
     var channels: AblySDKRealtimeChannels { get }
     var connection: AblySDKConnection { get }
@@ -12,10 +14,12 @@ public protocol AblySDKRealtime {
     func close()
 }
 
+//sourcery: AutoMockable
 public protocol AblySDKRealtimeChannels {
     func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions?) -> AblySDKRealtimeChannel
 }
 
+//sourcery: AutoMockable
 public protocol AblySDKRealtimeChannel {
     var presence: AblySDKRealtimePresence { get }
     @discardableResult func subscribe(_ name: String, callback: @escaping ARTMessageCallback) -> AblySDKEventListener?
@@ -25,6 +29,7 @@ public protocol AblySDKRealtimeChannel {
     func publish(_ messages: [ARTMessage], callback: ARTCallback?)
 }
 
+//sourcery: AutoMockable
 public protocol AblySDKRealtimePresence {
     func get(_ callback: @escaping ARTPresenceMessagesCallback)
     func enter(_ data: Any?, callback: ARTCallback?)

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -10,6 +10,7 @@ public protocol AblySDKRealtimeFactory {
 public protocol AblySDKRealtime {
     var channels: AblySDKRealtimeChannels { get }
     var connection: AblySDKConnection { get }
+    var auth: AblySDKAuth { get }
     
     func close()
 }
@@ -27,6 +28,7 @@ public protocol AblySDKRealtimeChannel {
     func detach(_ callback: ARTCallback?)
     @discardableResult func on(_ callback: @escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener
     func publish(_ messages: [ARTMessage], callback: ARTCallback?)
+    func attach(_ callback: ARTCallback?)
 }
 
 //sourcery: AutoMockable
@@ -42,6 +44,11 @@ public protocol AblySDKRealtimePresence {
 //sourcery: AutoMockable
 public protocol AblySDKConnection {
     @discardableResult func on(_ callback: @escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener
+}
+
+//sourcery: AutoMockable
+public protocol AblySDKAuth {
+    func authorize(_ callback: @escaping ARTTokenDetailsCallback)
 }
 
 public protocol AblySDKEventListener {}

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -53,6 +53,7 @@ class DefaultPublisherBuilder: PublisherBuilder {
         }
         
         let defaultAbly = DefaultAbly(
+            factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
             mode: .publish,
             logger: Logger(

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
@@ -37,6 +37,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
         }
 
         let defaultAbly = DefaultAbly(
+            factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
             mode: .subscribe,
             logger: Logger(

--- a/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
+++ b/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
@@ -1,0 +1,335 @@
+import XCTest
+import AblyAssetTrackingInternal
+import AblyAssetTrackingCore
+import Ably
+import Logging
+
+class DefaultAblyTests: XCTestCase {
+    let logger = Logger(label: "com.ably.tracking.DefaultAblyTests")
+
+    func test_connect_whenNotConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itFails() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let auth = AblySDKAuthMock()
+        auth.authorizeClosure = { callback in
+            callback(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""), nil)
+        }
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        realtime.auth = auth
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration(apiKey: "abc123")
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly fails to connect")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                XCTFail("Unexpected success in ably.connect")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(presence.enterCallbackCallsCount, 1)
+    }
+    
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterSucceeds_itSucceeds() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(nil)
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly successfully connects")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unexpected failure in ably.connect: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(presence.enterCallbackCallsCount, 1)
+    }
+    
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterFails_withAnErrorUnrelatedToCapabilities_itFails() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(ARTErrorInfo.createUnknownError())
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly fails to connect")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                XCTFail("Unexpected success in ably.connect")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(presence.enterCallbackCallsCount, 1)
+    }
+    
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itCallsAuthorize_andWhenAuthorizeSucceeds_itAttachesToTheChannel_andWhenAttachFails_itFails() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        channel.attachClosure = { callback in
+            callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+        }
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let auth = AblySDKAuthMock()
+        auth.authorizeClosure = { callback in
+            callback(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""), nil)
+        }
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        realtime.auth = auth
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly fails to connect")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                XCTFail("Unexpected success in ably.connect")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(channel.attachCallsCount, 1)
+        XCTAssertEqual(presence.enterCallbackCallsCount, 1)
+        XCTAssertEqual(auth.authorizeCallsCount, 1)
+    }
+
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itCallsAuthorize_andWhenAuthorizeSucceeds_itAttachesToTheChannel_andWhenAttachSucceeds_itRetriesPresenceEnter_andWhenTheSecondCallToPresenceEnterSucceeds_itSucceeds() {
+        let presence = AblySDKRealtimePresenceMock()
+        var hasEnterFailed = false
+        presence.enterCallbackClosure = { data, callback in
+            if hasEnterFailed {
+                callback?(nil)
+            } else {
+                hasEnterFailed = true
+                callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+            }
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        channel.attachClosure = { callback in
+            callback?(nil)
+        }
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let auth = AblySDKAuthMock()
+        auth.authorizeClosure = { callback in
+            callback(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""), nil)
+        }
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        realtime.auth = auth
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly successfully connects")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unexpected failure in ably.connect: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(channel.attachCallsCount, 1)
+        XCTAssertEqual(presence.enterCallbackCallsCount, 2)
+        XCTAssertEqual(auth.authorizeCallsCount, 1)
+    }
+    
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itCallsAuthorize_andWhenAuthorizeSucceeds_itAttachesToTheChannel_andWhenAttachSucceeds_itRetriesPresenceEnter_andWhenTheSecondCallToPresenceEnterFails_itFails() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        channel.attachClosure = { callback in
+            callback?(nil)
+        }
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let auth = AblySDKAuthMock()
+        auth.authorizeClosure = { callback in
+            callback(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""), nil)
+        }
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        realtime.auth = auth
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly fails to connect")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                XCTFail("Unexpected success in ably.connect")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(channel.attachCallsCount, 1)
+        XCTAssertEqual(presence.enterCallbackCallsCount, 2)
+        XCTAssertEqual(auth.authorizeCallsCount, 1)
+    }
+    
+    func test_connect_whenConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itCallsAuthorize_andWhenAuthorizeFails_itFails() {
+        let presence = AblySDKRealtimePresenceMock()
+        presence.enterCallbackClosure = { data, callback in
+            callback?(ARTErrorInfo.create(withCode: 40160, message: ""))
+        }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        channel.presence = presence
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let auth = AblySDKAuthMock()
+        auth.authorizeClosure = { callback in
+            callback(nil, NSError(domain: "", code: 0))
+        }
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        realtime.auth = auth
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        
+        let expectation = expectation(description: "DefaultAbly fails to connect")
+        ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
+            switch result {
+            case .success:
+                XCTFail("Unexpected success in ably.connect")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+                
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertEqual(presence.enterCallbackCallsCount, 1)
+        XCTAssertEqual(auth.authorizeCallsCount, 1)
+    }
+}

--- a/Tests/InternalTests/Mocks/AblySDKMocks.swift
+++ b/Tests/InternalTests/Mocks/AblySDKMocks.swift
@@ -1,0 +1,335 @@
+// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
+
+import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
+import Ably
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class AblySDKConnectionMock: AblySDKConnection {
+
+    //MARK: - on
+
+    var onCallsCount = 0
+    var onCalled: Bool {
+        return onCallsCount > 0
+    }
+    var onReceivedCallback: ((ARTConnectionStateChange) -> Void)?
+    var onReceivedInvocations: [((ARTConnectionStateChange) -> Void)] = []
+    var onReturnValue: AblySDKEventListener!
+    var onClosure: ((@escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener)?
+
+    @discardableResult
+    func on(_ callback: @escaping (ARTConnectionStateChange) -> Void) -> AblySDKEventListener {
+        onCallsCount += 1
+        onReceivedCallback = callback
+        onReceivedInvocations.append(callback)
+        if let onClosure = onClosure {
+            return onClosure(callback)
+        } else {
+            return onReturnValue
+        }
+    }
+
+}
+class AblySDKRealtimeMock: AblySDKRealtime {
+    var channels: AblySDKRealtimeChannels {
+        get { return underlyingChannels }
+        set(value) { underlyingChannels = value }
+    }
+    var underlyingChannels: AblySDKRealtimeChannels!
+    var connection: AblySDKConnection {
+        get { return underlyingConnection }
+        set(value) { underlyingConnection = value }
+    }
+    var underlyingConnection: AblySDKConnection!
+
+    //MARK: - close
+
+    var closeCallsCount = 0
+    var closeCalled: Bool {
+        return closeCallsCount > 0
+    }
+    var closeClosure: (() -> Void)?
+
+    func close() {
+        closeCallsCount += 1
+        closeClosure?()
+    }
+
+}
+class AblySDKRealtimeChannelMock: AblySDKRealtimeChannel {
+    var presence: AblySDKRealtimePresence {
+        get { return underlyingPresence }
+        set(value) { underlyingPresence = value }
+    }
+    var underlyingPresence: AblySDKRealtimePresence!
+
+    //MARK: - subscribe
+
+    var subscribeCallbackCallsCount = 0
+    var subscribeCallbackCalled: Bool {
+        return subscribeCallbackCallsCount > 0
+    }
+    var subscribeCallbackReceivedArguments: (name: String, callback: ARTMessageCallback)?
+    var subscribeCallbackReceivedInvocations: [(name: String, callback: ARTMessageCallback)] = []
+    var subscribeCallbackReturnValue: AblySDKEventListener?
+    var subscribeCallbackClosure: ((String, @escaping ARTMessageCallback) -> AblySDKEventListener?)?
+
+    @discardableResult
+    func subscribe(_ name: String, callback: @escaping ARTMessageCallback) -> AblySDKEventListener? {
+        subscribeCallbackCallsCount += 1
+        subscribeCallbackReceivedArguments = (name: name, callback: callback)
+        subscribeCallbackReceivedInvocations.append((name: name, callback: callback))
+        if let subscribeCallbackClosure = subscribeCallbackClosure {
+            return subscribeCallbackClosure(name, callback)
+        } else {
+            return subscribeCallbackReturnValue
+        }
+    }
+
+    //MARK: - unsubscribe
+
+    var unsubscribeCallsCount = 0
+    var unsubscribeCalled: Bool {
+        return unsubscribeCallsCount > 0
+    }
+    var unsubscribeClosure: (() -> Void)?
+
+    func unsubscribe() {
+        unsubscribeCallsCount += 1
+        unsubscribeClosure?()
+    }
+
+    //MARK: - detach
+
+    var detachCallsCount = 0
+    var detachCalled: Bool {
+        return detachCallsCount > 0
+    }
+    var detachReceivedCallback: ARTCallback?
+    var detachReceivedInvocations: [ARTCallback?] = []
+    var detachClosure: ((ARTCallback?) -> Void)?
+
+    func detach(_ callback: ARTCallback?) {
+        detachCallsCount += 1
+        detachReceivedCallback = callback
+        detachReceivedInvocations.append(callback)
+        detachClosure?(callback)
+    }
+
+    //MARK: - on
+
+    var onCallsCount = 0
+    var onCalled: Bool {
+        return onCallsCount > 0
+    }
+    var onReceivedCallback: ((ARTChannelStateChange) -> ())?
+    var onReceivedInvocations: [((ARTChannelStateChange) -> ())] = []
+    var onReturnValue: AblySDKEventListener!
+    var onClosure: ((@escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener)?
+
+    @discardableResult
+    func on(_ callback: @escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener {
+        onCallsCount += 1
+        onReceivedCallback = callback
+        onReceivedInvocations.append(callback)
+        if let onClosure = onClosure {
+            return onClosure(callback)
+        } else {
+            return onReturnValue
+        }
+    }
+
+    //MARK: - publish
+
+    var publishCallbackCallsCount = 0
+    var publishCallbackCalled: Bool {
+        return publishCallbackCallsCount > 0
+    }
+    var publishCallbackReceivedArguments: (messages: [ARTMessage], callback: ARTCallback?)?
+    var publishCallbackReceivedInvocations: [(messages: [ARTMessage], callback: ARTCallback?)] = []
+    var publishCallbackClosure: (([ARTMessage], ARTCallback?) -> Void)?
+
+    func publish(_ messages: [ARTMessage], callback: ARTCallback?) {
+        publishCallbackCallsCount += 1
+        publishCallbackReceivedArguments = (messages: messages, callback: callback)
+        publishCallbackReceivedInvocations.append((messages: messages, callback: callback))
+        publishCallbackClosure?(messages, callback)
+    }
+
+}
+class AblySDKRealtimeChannelsMock: AblySDKRealtimeChannels {
+
+    //MARK: - getChannelFor
+
+    var getChannelForTrackingIdOptionsCallsCount = 0
+    var getChannelForTrackingIdOptionsCalled: Bool {
+        return getChannelForTrackingIdOptionsCallsCount > 0
+    }
+    var getChannelForTrackingIdOptionsReceivedArguments: (trackingId: String, options: ARTRealtimeChannelOptions?)?
+    var getChannelForTrackingIdOptionsReceivedInvocations: [(trackingId: String, options: ARTRealtimeChannelOptions?)] = []
+    var getChannelForTrackingIdOptionsReturnValue: AblySDKRealtimeChannel!
+    var getChannelForTrackingIdOptionsClosure: ((String, ARTRealtimeChannelOptions?) -> AblySDKRealtimeChannel)?
+
+    func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions?) -> AblySDKRealtimeChannel {
+        getChannelForTrackingIdOptionsCallsCount += 1
+        getChannelForTrackingIdOptionsReceivedArguments = (trackingId: trackingId, options: options)
+        getChannelForTrackingIdOptionsReceivedInvocations.append((trackingId: trackingId, options: options))
+        if let getChannelForTrackingIdOptionsClosure = getChannelForTrackingIdOptionsClosure {
+            return getChannelForTrackingIdOptionsClosure(trackingId, options)
+        } else {
+            return getChannelForTrackingIdOptionsReturnValue
+        }
+    }
+
+}
+class AblySDKRealtimeFactoryMock: AblySDKRealtimeFactory {
+
+    //MARK: - create
+
+    var createWithConfigurationCallsCount = 0
+    var createWithConfigurationCalled: Bool {
+        return createWithConfigurationCallsCount > 0
+    }
+    var createWithConfigurationReceivedConfiguration: ConnectionConfiguration?
+    var createWithConfigurationReceivedInvocations: [ConnectionConfiguration] = []
+    var createWithConfigurationReturnValue: AblySDKRealtime!
+    var createWithConfigurationClosure: ((ConnectionConfiguration) -> AblySDKRealtime)?
+
+    func create(withConfiguration configuration: ConnectionConfiguration) -> AblySDKRealtime {
+        createWithConfigurationCallsCount += 1
+        createWithConfigurationReceivedConfiguration = configuration
+        createWithConfigurationReceivedInvocations.append(configuration)
+        if let createWithConfigurationClosure = createWithConfigurationClosure {
+            return createWithConfigurationClosure(configuration)
+        } else {
+            return createWithConfigurationReturnValue
+        }
+    }
+
+}
+class AblySDKRealtimePresenceMock: AblySDKRealtimePresence {
+
+    //MARK: - get
+
+    var getCallsCount = 0
+    var getCalled: Bool {
+        return getCallsCount > 0
+    }
+    var getReceivedCallback: ARTPresenceMessagesCallback?
+    var getReceivedInvocations: [ARTPresenceMessagesCallback] = []
+    var getClosure: ((@escaping ARTPresenceMessagesCallback) -> Void)?
+
+    func get(_ callback: @escaping ARTPresenceMessagesCallback) {
+        getCallsCount += 1
+        getReceivedCallback = callback
+        getReceivedInvocations.append(callback)
+        getClosure?(callback)
+    }
+
+    //MARK: - enter
+
+    var enterCallbackCallsCount = 0
+    var enterCallbackCalled: Bool {
+        return enterCallbackCallsCount > 0
+    }
+    var enterCallbackReceivedArguments: (data: Any?, callback: ARTCallback?)?
+    var enterCallbackReceivedInvocations: [(data: Any?, callback: ARTCallback?)] = []
+    var enterCallbackClosure: ((Any?, ARTCallback?) -> Void)?
+
+    func enter(_ data: Any?, callback: ARTCallback?) {
+        enterCallbackCallsCount += 1
+        enterCallbackReceivedArguments = (data: data, callback: callback)
+        enterCallbackReceivedInvocations.append((data: data, callback: callback))
+        enterCallbackClosure?(data, callback)
+    }
+
+    //MARK: - update
+
+    var updateCallbackCallsCount = 0
+    var updateCallbackCalled: Bool {
+        return updateCallbackCallsCount > 0
+    }
+    var updateCallbackReceivedArguments: (data: Any?, callback: ARTCallback?)?
+    var updateCallbackReceivedInvocations: [(data: Any?, callback: ARTCallback?)] = []
+    var updateCallbackClosure: ((Any?, ARTCallback?) -> Void)?
+
+    func update(_ data: Any?, callback: ARTCallback?) {
+        updateCallbackCallsCount += 1
+        updateCallbackReceivedArguments = (data: data, callback: callback)
+        updateCallbackReceivedInvocations.append((data: data, callback: callback))
+        updateCallbackClosure?(data, callback)
+    }
+
+    //MARK: - leave
+
+    var leaveCallbackCallsCount = 0
+    var leaveCallbackCalled: Bool {
+        return leaveCallbackCallsCount > 0
+    }
+    var leaveCallbackReceivedArguments: (data: Any?, callback: ARTCallback?)?
+    var leaveCallbackReceivedInvocations: [(data: Any?, callback: ARTCallback?)] = []
+    var leaveCallbackClosure: ((Any?, ARTCallback?) -> Void)?
+
+    func leave(_ data: Any?, callback: ARTCallback?) {
+        leaveCallbackCallsCount += 1
+        leaveCallbackReceivedArguments = (data: data, callback: callback)
+        leaveCallbackReceivedInvocations.append((data: data, callback: callback))
+        leaveCallbackClosure?(data, callback)
+    }
+
+    //MARK: - subscribe
+
+    var subscribeCallsCount = 0
+    var subscribeCalled: Bool {
+        return subscribeCallsCount > 0
+    }
+    var subscribeReceivedCallback: ARTPresenceMessageCallback?
+    var subscribeReceivedInvocations: [ARTPresenceMessageCallback] = []
+    var subscribeReturnValue: AblySDKEventListener?
+    var subscribeClosure: ((@escaping ARTPresenceMessageCallback) -> AblySDKEventListener?)?
+
+    @discardableResult
+    func subscribe(_ callback: @escaping ARTPresenceMessageCallback) -> AblySDKEventListener? {
+        subscribeCallsCount += 1
+        subscribeReceivedCallback = callback
+        subscribeReceivedInvocations.append(callback)
+        if let subscribeClosure = subscribeClosure {
+            return subscribeClosure(callback)
+        } else {
+            return subscribeReturnValue
+        }
+    }
+
+    //MARK: - unsubscribe
+
+    var unsubscribeCallsCount = 0
+    var unsubscribeCalled: Bool {
+        return unsubscribeCallsCount > 0
+    }
+    var unsubscribeClosure: (() -> Void)?
+
+    func unsubscribe() {
+        unsubscribeCallsCount += 1
+        unsubscribeClosure?()
+    }
+
+}

--- a/Tests/InternalTests/Mocks/AblySDKMocks.swift
+++ b/Tests/InternalTests/Mocks/AblySDKMocks.swift
@@ -23,6 +23,26 @@ import Ably
 
 
 
+class AblySDKAuthMock: AblySDKAuth {
+
+    //MARK: - authorize
+
+    var authorizeCallsCount = 0
+    var authorizeCalled: Bool {
+        return authorizeCallsCount > 0
+    }
+    var authorizeReceivedCallback: ARTTokenDetailsCallback?
+    var authorizeReceivedInvocations: [ARTTokenDetailsCallback] = []
+    var authorizeClosure: ((@escaping ARTTokenDetailsCallback) -> Void)?
+
+    func authorize(_ callback: @escaping ARTTokenDetailsCallback) {
+        authorizeCallsCount += 1
+        authorizeReceivedCallback = callback
+        authorizeReceivedInvocations.append(callback)
+        authorizeClosure?(callback)
+    }
+
+}
 class AblySDKConnectionMock: AblySDKConnection {
 
     //MARK: - on
@@ -60,6 +80,11 @@ class AblySDKRealtimeMock: AblySDKRealtime {
         set(value) { underlyingConnection = value }
     }
     var underlyingConnection: AblySDKConnection!
+    var auth: AblySDKAuth {
+        get { return underlyingAuth }
+        set(value) { underlyingAuth = value }
+    }
+    var underlyingAuth: AblySDKAuth!
 
     //MARK: - close
 
@@ -173,6 +198,23 @@ class AblySDKRealtimeChannelMock: AblySDKRealtimeChannel {
         publishCallbackReceivedArguments = (messages: messages, callback: callback)
         publishCallbackReceivedInvocations.append((messages: messages, callback: callback))
         publishCallbackClosure?(messages, callback)
+    }
+
+    //MARK: - attach
+
+    var attachCallsCount = 0
+    var attachCalled: Bool {
+        return attachCallsCount > 0
+    }
+    var attachReceivedCallback: ARTCallback?
+    var attachReceivedInvocations: [ARTCallback?] = []
+    var attachClosure: ((ARTCallback?) -> Void)?
+
+    func attach(_ callback: ARTCallback?) {
+        attachCallsCount += 1
+        attachReceivedCallback = callback
+        attachReceivedInvocations.append(callback)
+        attachClosure?(callback)
     }
 
 }

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -69,6 +69,7 @@ class ChannelModesTests: XCTestCase {
         let publisherConnectionConfiguration = ConnectionConfiguration(apiKey: ablyApiKey, clientId: clientId)
         
         let defaultAbly = DefaultAbly(
+            factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
             logger: .init(label: "com.ably.tracking.SystemTests")

--- a/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
@@ -63,7 +63,7 @@ class PublisherAuthenticationSystemTests: XCTestCase {
         
         let fetchedTokenDetails = AuthHelper().requestToken(
             options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
-            clientId: keyName
+            tokenParams: ARTTokenParams(clientId: keyName)
         )
         
         let connectionConfiguration = ConnectionConfiguration(clientId: keyName, authCallback: { tokenParams, resultHandler in
@@ -84,7 +84,7 @@ class PublisherAuthenticationSystemTests: XCTestCase {
         
         let fetchedTokenString = AuthHelper().requestToken(
             options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
-            clientId: keyName
+            tokenParams: ARTTokenParams(clientId: keyName)
         )?.token
                 
         let connectionConfiguration = ConnectionConfiguration(clientId: keyName, authCallback: { tokenParams, resultHandler in

--- a/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
@@ -112,15 +112,21 @@ class PublisherAuthenticationSystemTests: XCTestCase {
         testPublisherTrack(configuration: connectionConfiguration)
     }
     
-    private func testPublisherTrack(configuration: ConnectionConfiguration) {
+    private func createAndStartPublisher(connectionConfiguration: ConnectionConfiguration) -> Publisher {
         let resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
         let publisher = try! PublisherFactory.publishers()
-            .connection(configuration)
+            .connection(connectionConfiguration)
             .mapboxConfiguration(MapboxConfiguration(mapboxKey: Secrets.mapboxAccessToken))
             .locationSource(LocationSource(locationSource: [CLLocation(latitude: 0.0, longitude: 0.0), CLLocation(latitude: 1.0, longitude: 1.0)]))
             .routingProfile(.driving)
             .resolutionPolicyFactory(DefaultResolutionPolicyFactory(defaultResolution: resolution))
             .start() // Doesn't start publishing, its just a `build()` publisher call.
+        
+        return publisher
+    }
+    
+    private func testPublisherTrack(configuration: ConnectionConfiguration) {
+        let publisher = createAndStartPublisher(connectionConfiguration: configuration)
 
         // TODO check that connection is made/ Await successfully connection callback with an expectation
         // Here, I am creating a trackable instead of just checking the connection, because there doesn't
@@ -144,6 +150,65 @@ class PublisherAuthenticationSystemTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 10)
+    }
+    
+    private func requestToken(withPublisherCapabilitiesForTrackableIds trackableIds: [String], clientId: String) -> TokenDetails? {
+        let capabilities = trackableIds.reduce([:]) { capabilities, trackableId -> [String : [String]] in
+            var newCapabilities = capabilities
+            newCapabilities["tracking:\(trackableId)"] = ["publish", "subscribe", "presence"]
+            return newCapabilities
+        }
+        
+        let tokenParams = ARTTokenParams(clientId: clientId)
+        tokenParams.capability = try! capabilities.toJSONString()
+        
+        return AuthHelper().requestToken(
+            options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
+            tokenParams: tokenParams
+        )
+    }
+    
+    func testPublisher_usingTokenAuth_addTrackable_whenEnterPresenceGivesCapabilityError_reauthorizesAblyAndEntersPresenceWithNewToken() throws {
+        let keyTokens = Secrets.ablyApiKey.split(separator: ":")
+        let keyName = String(keyTokens[0])
+        
+        let trackableId = UUID().uuidString
+        let otherTrackableId = UUID().uuidString
+        
+        // These are being done outside of the authCallback because it seems like calling requestToken inside there causes some sort of a hang. Tried to sort it out but didn’t get anywhere quickly.
+        let initialToken = try XCTUnwrap(requestToken(withPublisherCapabilitiesForTrackableIds: [otherTrackableId], clientId: keyName))
+        let updatedToken = try XCTUnwrap(requestToken(withPublisherCapabilitiesForTrackableIds: [otherTrackableId, trackableId], clientId: keyName))
+        
+        var hasRequestedInitialToken = false
+        var hasRequestedUpdatedToken = false
+        
+        let connectionConfiguration = ConnectionConfiguration(clientId: keyName, authCallback: { tokenParams, resultHandler in
+            if !hasRequestedInitialToken {
+                hasRequestedInitialToken = true
+                resultHandler(.success(.tokenDetails(initialToken)))
+            } else {
+                hasRequestedUpdatedToken = true
+                resultHandler(.success(.tokenDetails(updatedToken)))
+            }
+        })
+        
+        let publisher = createAndStartPublisher(connectionConfiguration: connectionConfiguration)
+        
+        let trackable = Trackable(id: trackableId)
+        let addTrackableExpectation = expectation(description: "Publisher successfully adds trackable")
+        publisher.add(trackable: trackable) { result in
+            switch result {
+            case .success:
+                addTrackableExpectation.fulfill()
+            case let .failure(errorInformation):
+                XCTFail("Failed to add trackable with error \(errorInformation)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        XCTAssertTrue(hasRequestedInitialToken)
+        XCTAssertTrue(hasRequestedUpdatedToken)
     }
 }
 

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -63,6 +63,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let publisherConnectionConfiguration = ConnectionConfiguration(apiKey: Secrets.ablyApiKey, clientId: publisherClientId)
         
         let defaultAbly = DefaultAbly(
+            factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
             logger: .init(label: "com.ably.tracking.SystemTests")
@@ -143,6 +144,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let publisherConnectionConfiguration = ConnectionConfiguration(apiKey: Secrets.ablyApiKey, clientId: publisherClientId)
         
         let defaultAbly = DefaultAbly(
+            factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
             logger: .init(label: "com.ably.tracking.SystemTests")

--- a/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
@@ -105,13 +105,17 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         testSubscriberConnection(configuration: connectionConfiguration)
     }
     
-    private func testSubscriberConnection(configuration: ConnectionConfiguration) {
-        var resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
-        let subscriberStartExpectation = self.expectation(description: "Subscriber start expectation")
-        let subscriber = SubscriberFactory.subscribers()
-            .connection(configuration)
+    private func createSubscriberBuilder(connectionConfiguration: ConnectionConfiguration) -> SubscriberBuilder {
+        let resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
+        return SubscriberFactory.subscribers()
+            .connection(connectionConfiguration)
             .resolution(resolution)
             .trackingId("Trackable ID")
+    }
+    
+    private func testSubscriberConnection(configuration: ConnectionConfiguration) {
+        let subscriberStartExpectation = self.expectation(description: "Subscriber start expectation")
+        let subscriber = createSubscriberBuilder(connectionConfiguration: configuration)
             .start { result in
                 switch result {
                 case .success: ()
@@ -123,7 +127,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         waitForExpectations(timeout: 10.0)
     
         let resolutionCompletionExpectation = self.expectation(description: "Resolution completion expectation")
-        resolution = Resolution(accuracy: .balanced, desiredInterval: 1000, minimumDisplacement: 100)
+        let resolution = Resolution(accuracy: .balanced, desiredInterval: 1000, minimumDisplacement: 100)
         subscriber?.resolutionPreference(resolution: resolution, completion: { result in
             switch result {
             case .success: ()

--- a/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
@@ -105,17 +105,17 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         testSubscriberConnection(configuration: connectionConfiguration)
     }
     
-    private func createSubscriberBuilder(connectionConfiguration: ConnectionConfiguration) -> SubscriberBuilder {
+    private func createSubscriberBuilder(connectionConfiguration: ConnectionConfiguration, trackingId: String) -> SubscriberBuilder {
         let resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
         return SubscriberFactory.subscribers()
             .connection(connectionConfiguration)
             .resolution(resolution)
-            .trackingId("Trackable ID")
+            .trackingId(trackingId)
     }
     
     private func testSubscriberConnection(configuration: ConnectionConfiguration) {
         let subscriberStartExpectation = self.expectation(description: "Subscriber start expectation")
-        let subscriber = createSubscriberBuilder(connectionConfiguration: configuration)
+        let subscriber = createSubscriberBuilder(connectionConfiguration: configuration, trackingId: "Trackable ID")
             .start { result in
                 switch result {
                 case .success: ()
@@ -144,5 +144,72 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
             subscriberStopExpectation.fulfill()
         })
         waitForExpectations(timeout: 10.0)
+    }
+    
+    private func requestToken(withSubscriberCapabilitiesForTrackableIds trackableIds: [String], clientId: String) -> TokenDetails? {
+        let capabilities = trackableIds.reduce([:]) { capabilities, trackableId -> [String : [String]] in
+            var newCapabilities = capabilities
+            newCapabilities["tracking:\(trackableId)"] = ["publish", "subscribe", "presence", "history"]
+            return newCapabilities
+        }
+        
+        let tokenParams = ARTTokenParams(clientId: clientId)
+        tokenParams.capability = try! capabilities.toJSONString()
+        
+        return AuthHelper().requestToken(
+            options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
+            tokenParams: tokenParams
+        )
+    }
+    
+    func testSubscriber_usingTokenAuth_start_whenEnterPresenceGivesCapabilityError_reauthorizesAblyAndEntersPresenceWithNewToken() throws {
+        let keyTokens = Secrets.ablyApiKey.split(separator: ":")
+        let keyName = String(keyTokens[0])
+        
+        let trackableId = UUID().uuidString
+        let otherTrackableId = UUID().uuidString
+        
+        // These are being done outside of the authCallback because it seems like calling requestToken inside there causes some sort of a hang. Tried to sort it out but didn’t get anywhere quickly.
+        let initialToken = try XCTUnwrap(requestToken(withSubscriberCapabilitiesForTrackableIds: [otherTrackableId], clientId: keyName))
+        let updatedToken = try XCTUnwrap(requestToken(withSubscriberCapabilitiesForTrackableIds: [otherTrackableId, trackableId], clientId: keyName))
+        
+        var hasRequestedInitialToken = false
+        var hasRequestedUpdatedToken = false
+        
+        let connectionConfiguration = ConnectionConfiguration(clientId: keyName, authCallback: { tokenParams, resultHandler in
+            if !hasRequestedInitialToken {
+                hasRequestedInitialToken = true
+                resultHandler(.success(.tokenDetails(initialToken)))
+            } else {
+                hasRequestedUpdatedToken = true
+                resultHandler(.success(.tokenDetails(updatedToken)))
+            }
+        })
+        
+        let subscriberStartExpectation = expectation(description: "Wait for subscriber to start")
+        let subscriber = createSubscriberBuilder(connectionConfiguration: connectionConfiguration, trackingId: trackableId)
+            .start { result in
+                switch result {
+                case .success:
+                    subscriberStartExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("Subscriber start failed with error: \(error)")
+                }
+            }
+        waitForExpectations(timeout: 10.0)
+        
+        XCTAssertTrue(hasRequestedInitialToken)
+        XCTAssertTrue(hasRequestedUpdatedToken)
+        
+        let subscriberStopExpectation = expectation(description: "Wait for subscriber to stop")
+        subscriber?.stop(completion: { result in
+            switch result {
+            case .success:
+                subscriberStopExpectation.fulfill()
+            case let .failure(errorInfo):
+                XCTFail("Failed to stop subscriber, with error \(errorInfo)")
+            }
+        })
+        waitForExpectations(timeout: 10)
     }
 }

--- a/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/SubscriberAuthenticationSystemTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import AblyAssetTrackingCore
 import AblyAssetTrackingSubscriber
 import CoreLocation
+import Ably
 
 class SubscriberAuthenticationSystemTests: XCTestCase {
     
@@ -55,7 +56,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
     func testSubscriberConnectsWithTokenDetails() throws {
         let fetchedTokenDetails = AuthHelper().requestToken(
             options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
-            clientId: clientId
+            tokenParams: ARTTokenParams(clientId: clientId)
         )
         
         let connectionConfiguration = ConnectionConfiguration(clientId: clientId, authCallback: { tokenParams, resultHandler in
@@ -76,7 +77,7 @@ class SubscriberAuthenticationSystemTests: XCTestCase {
         
         let fetchedTokenString = AuthHelper().requestToken(
             options: RestHelper.clientOptions(true, key: Secrets.ablyApiKey),
-            clientId: keyName
+            tokenParams: ARTTokenParams(clientId: keyName)
         )?.token
                 
         let connectionConfiguration = ConnectionConfiguration(clientId: keyName, authCallback: { tokenParams, resultHandler in

--- a/Tests/SystemTests/Utils/AuthHelper.swift
+++ b/Tests/SystemTests/Utils/AuthHelper.swift
@@ -4,11 +4,10 @@ import Ably
 import XCTest
 
 class AuthHelper {
-    func requestToken(options: ARTClientOptions, clientId: String? = nil) -> TokenDetails? {
+    func requestToken(options: ARTClientOptions, tokenParams: ARTTokenParams = ARTTokenParams(clientId: nil)) -> TokenDetails? {
         var requestCompleted = false
         var fetchedTokenDetails: TokenDetails?
         let client = ARTRest(options: options)
-        let tokenParams = ARTTokenParams(clientId: clientId)
         
         client.auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
             if let error = error {


### PR DESCRIPTION
This closes #311. Please review commit-by-commit; there's lots of information in the commit messages.

For anyone just passing by, it's worth noting that this introduces a new piece of tooling (https://github.com/krzysztofzablocki/Sourcery). Opinions welcome.