### PR TITLE
Remove outdated terminology from class and variable names

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
@@ -1,14 +1,14 @@
 import Foundation
 import AblyAssetTrackingCore
 
-public protocol AblyPublisherServiceDelegate: AnyObject {
+public protocol AblyPublisherDelegate: AnyObject {
     /**
      Tells the delegate that `Ably` client connection state changed.
      
      - Parameter sender:    The `AblyPublisher` object which is delegating the change.
      - Parameter state:     The `ConnectionState` object
      */
-    func publisherService(sender: AblyPublisher, didChangeConnectionState state: ConnectionState)
+    func ablyPublisher(sender: AblyPublisher, didChangeConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel connection state changed.
@@ -17,7 +17,7 @@ public protocol AblyPublisherServiceDelegate: AnyObject {
      - Parameter state:         The `ConnectionState` object
      - Parameter trackable:     The `Trackable` object affected by the change
      */
-    func publisherService(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable)
+    func ablyPublisher(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable)
     
     /**
      Tells the delegate that an error occurred.
@@ -27,7 +27,7 @@ public protocol AblyPublisherServiceDelegate: AnyObject {
      - Parameter sender:        The `AblyPublisher` object which is delegating the change.
      - Parameter error:         The `ErrorInformation` object that contains info about error.
      */
-    func publisherService(sender: AblyPublisher, didFailWithError error: ErrorInformation)
+    func ablyPublisher(sender: AblyPublisher, didFailWithError error: ErrorInformation)
     
     /**
      Tells the delegate that channel presence data was changed.
@@ -38,7 +38,7 @@ public protocol AblyPublisherServiceDelegate: AnyObject {
      - Parameter presenceData:  The `PresenceData` object that contains info related to presence change.
      - Parameter clientId:      The `Ably` client identifier.
      */
-    func publisherService(
+    func ablyPublisher(
         sender: AblyPublisher,
         didReceivePresenceUpdate presence: Presence,
         forTrackable trackable: Trackable,
@@ -51,9 +51,9 @@ public protocol AblyPublisher: AblyCommon {
     /**
      The delegate of the `Ably` wrapper object.
      
-     The methods declared by the `AblyPublisherServiceDelegate` protocol allow the adopting delegate to respond to messages from the `Ably` wrapper class..
+     The methods declared by the `AblyPublisherDelegate` protocol allow the adopting delegate to respond to messages from the `Ably` wrapper class..
      */
-    var publisherDelegate: AblyPublisherServiceDelegate? { get set }
+    var publisherDelegate: AblyPublisherDelegate? { get set }
     
     /**
      Sends an enhanced location update to the channel.

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
@@ -8,7 +8,7 @@ public protocol AblyPublisherDelegate: AnyObject {
      - Parameter sender:    The `AblyPublisher` object which is delegating the change.
      - Parameter state:     The `ConnectionState` object
      */
-    func ablyPublisher(sender: AblyPublisher, didChangeConnectionState state: ConnectionState)
+    func ablyPublisher(_ sender: AblyPublisher, didChangeConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel connection state changed.
@@ -17,7 +17,7 @@ public protocol AblyPublisherDelegate: AnyObject {
      - Parameter state:         The `ConnectionState` object
      - Parameter trackable:     The `Trackable` object affected by the change
      */
-    func ablyPublisher(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable)
+    func ablyPublisher(_ sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable)
     
     /**
      Tells the delegate that an error occurred.
@@ -27,7 +27,7 @@ public protocol AblyPublisherDelegate: AnyObject {
      - Parameter sender:        The `AblyPublisher` object which is delegating the change.
      - Parameter error:         The `ErrorInformation` object that contains info about error.
      */
-    func ablyPublisher(sender: AblyPublisher, didFailWithError error: ErrorInformation)
+    func ablyPublisher(_ sender: AblyPublisher, didFailWithError error: ErrorInformation)
     
     /**
      Tells the delegate that channel presence data was changed.
@@ -39,7 +39,7 @@ public protocol AblyPublisherDelegate: AnyObject {
      - Parameter clientId:      The `Ably` client identifier.
      */
     func ablyPublisher(
-        sender: AblyPublisher,
+        _ sender: AblyPublisher,
         didReceivePresenceUpdate presence: Presence,
         forTrackable trackable: Trackable,
         presenceData: PresenceData,

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
@@ -2,14 +2,14 @@ import Foundation
 import AblyAssetTrackingCore
 import CoreLocation
 
-public protocol AblySubscriberServiceDelegate: AnyObject {
+public protocol AblySubscriberDelegate: AnyObject {
     /**
      Tells the delegate that `Ably` client connection state changed.
      
      - Parameter sender:    The `AblySubscriber` object which is delegating the change.
      - Parameter state:     The `ConnectionState` object
      */
-    func subscriberService(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState)
+    func ablySubscriber(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel connection state changed.
@@ -17,7 +17,7 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter state:         The `ConnectionState` object
      */
-    func subscriberService(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState)
+    func ablySubscriber(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel presence was changed.
@@ -25,7 +25,7 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter presence:      The `Presence` object affected by the change.
      */
-    func subscriberService(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence)
+    func ablySubscriber(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence)
     
     /**
      Tells the delegate that an error occurred.
@@ -35,7 +35,7 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter error:         The `ErrorInformation` object that contains info about error.
      */
-    func subscriberService(sender: AblySubscriber, didFailWithError error: ErrorInformation)
+    func ablySubscriber(sender: AblySubscriber, didFailWithError error: ErrorInformation)
     
     /**
      Tells the delegate that published location was changed.
@@ -45,7 +45,7 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:              The `AblySubscriber` object which is delegating the change.
      - Parameter locationUpdate:      The `LocationUpdate` object that contains info about publisher `Enhanced` location.
      */
-    func subscriberService(sender: AblySubscriber, didReceiveEnhancedLocation locationUpdate: LocationUpdate)
+    func ablySubscriber(sender: AblySubscriber, didReceiveEnhancedLocation locationUpdate: LocationUpdate)
     
     /**
      Tells the delegate that published location was changed.
@@ -55,7 +55,7 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:              The `AblySubscriber` object which is delegating the change.
      - Parameter locationUpdate:      The `LocationUpdate` object that contains info about publisher `Raw` location.
      */
-    func subscriberService(sender: AblySubscriber, didReceiveRawLocation locationUpdate: LocationUpdate)
+    func ablySubscriber(sender: AblySubscriber, didReceiveRawLocation locationUpdate: LocationUpdate)
     
     /**
      Tells the delegate that resolution was changed.
@@ -66,16 +66,16 @@ public protocol AblySubscriberServiceDelegate: AnyObject {
      - Parameter sender:          The `AblySubscriber` object which is delegating the change.
      - Parameter resolution:      The `Resolution` object.
      */
-    func subscriberService(sender: AblySubscriber, didReceiveResolution resolution: Resolution)
+    func ablySubscriber(sender: AblySubscriber, didReceiveResolution resolution: Resolution)
 }
 
 public protocol AblySubscriber: AblyCommon {
     /**
      The delegate of the `Ably` wrapper object.
      
-     The methods declared by the `AblySubscriberServiceDelegate` protocol allow the adopting delegate to respond to messages from the `Ably` wrapper class..
+     The methods declared by the `AblySubscriberDelegate` protocol allow the adopting delegate to respond to messages from the `Ably` wrapper class..
      */
-    var subscriberDelegate: AblySubscriberServiceDelegate? { get set }
+    var subscriberDelegate: AblySubscriberDelegate? { get set }
     
     /**
      Observe  for the enhanced location change.

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
@@ -9,7 +9,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:    The `AblySubscriber` object which is delegating the change.
      - Parameter state:     The `ConnectionState` object
      */
-    func ablySubscriber(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState)
+    func ablySubscriber(_ sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel connection state changed.
@@ -17,7 +17,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter state:         The `ConnectionState` object
      */
-    func ablySubscriber(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState)
+    func ablySubscriber(_ sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState)
     
     /**
      Tells the delegate that channel presence was changed.
@@ -25,7 +25,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter presence:      The `Presence` object affected by the change.
      */
-    func ablySubscriber(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence)
+    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: Presence)
     
     /**
      Tells the delegate that an error occurred.
@@ -35,7 +35,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter error:         The `ErrorInformation` object that contains info about error.
      */
-    func ablySubscriber(sender: AblySubscriber, didFailWithError error: ErrorInformation)
+    func ablySubscriber(_ sender: AblySubscriber, didFailWithError error: ErrorInformation)
     
     /**
      Tells the delegate that published location was changed.
@@ -45,7 +45,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:              The `AblySubscriber` object which is delegating the change.
      - Parameter locationUpdate:      The `LocationUpdate` object that contains info about publisher `Enhanced` location.
      */
-    func ablySubscriber(sender: AblySubscriber, didReceiveEnhancedLocation locationUpdate: LocationUpdate)
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveEnhancedLocation locationUpdate: LocationUpdate)
     
     /**
      Tells the delegate that published location was changed.
@@ -55,7 +55,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:              The `AblySubscriber` object which is delegating the change.
      - Parameter locationUpdate:      The `LocationUpdate` object that contains info about publisher `Raw` location.
      */
-    func ablySubscriber(sender: AblySubscriber, didReceiveRawLocation locationUpdate: LocationUpdate)
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveRawLocation locationUpdate: LocationUpdate)
     
     /**
      Tells the delegate that resolution was changed.
@@ -66,7 +66,7 @@ public protocol AblySubscriberDelegate: AnyObject {
      - Parameter sender:          The `AblySubscriber` object which is delegating the change.
      - Parameter resolution:      The `Resolution` object.
      */
-    func ablySubscriber(sender: AblySubscriber, didReceiveResolution resolution: Resolution)
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveResolution resolution: Resolution)
 }
 
 public protocol AblySubscriber: AblyCommon {

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -176,11 +176,11 @@ public class DefaultAbly: AblyCommon {
             
             self.logger.debug("Connection to Ably changed. New state: \(receivedConnectionState.description)", source: String(describing: Self.self))
             self.publisherDelegate?.ablyPublisher(
-                sender: self,
+                self,
                 didChangeConnectionState: receivedConnectionState
             )
             self.subscriberDelegate?.ablySubscriber(
-                sender: self,
+                self,
                 didChangeClientConnectionState: receivedConnectionState
             )
         }
@@ -221,17 +221,17 @@ public class DefaultAbly: AblyCommon {
         )
         
         // AblySubscriber delegate
-        self.subscriberDelegate?.ablySubscriber(sender: self, didReceivePresenceUpdate: presence)
-        self.subscriberDelegate?.ablySubscriber(sender: self, didChangeChannelConnectionState: presence.action.toConnectionState())
+        self.subscriberDelegate?.ablySubscriber(self, didReceivePresenceUpdate: presence)
+        self.subscriberDelegate?.ablySubscriber(self, didChangeChannelConnectionState: presence.action.toConnectionState())
         
         // Deleagate `Publisher` resolution if present in PresenceData
         if let resolution = data.resolution, data.type == .publisher {
-            self.subscriberDelegate?.ablySubscriber(sender: self, didReceiveResolution: resolution)
+            self.subscriberDelegate?.ablySubscriber(self, didReceiveResolution: resolution)
         }
         
         // AblyPublisher delegate
         self.publisherDelegate?.ablyPublisher(
-            sender: self,
+            self,
             didReceivePresenceUpdate: presence,
             forTrackable: trackable,
             presenceData: data,
@@ -252,7 +252,7 @@ public class DefaultAbly: AblyCommon {
             let receivedConnectionState = stateChange.current.toConnectionState()
             
             self.logger.debug("Channel state for trackable \(trackable.id) changed. New state: \(receivedConnectionState.description)", source: String(describing: Self.self))
-            self.publisherDelegate?.ablyPublisher(sender: self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
+            self.publisherDelegate?.ablyPublisher(self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
         }
     }
     
@@ -318,7 +318,7 @@ extension DefaultAbly: AblySubscriber {
                     errorMessage: "Cannot parse message data for \(event.rawValue) event: \(String(describing: messageData))"
                 )
             )
-            subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: errorInformation)
+            subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
             
             return
         }
@@ -329,21 +329,21 @@ extension DefaultAbly: AblySubscriber {
                 let message: RawLocationUpdateMessage = try RawLocationUpdateMessage.fromJSONString(json)
                 let locationUpdate = RawLocationUpdate(location: message.location.toLocation())
                 locationUpdate.skippedLocations = message.skippedLocations.map { $0.toLocation() }
-                subscriberDelegate?.ablySubscriber(sender: self, didReceiveRawLocation: locationUpdate)
+                subscriberDelegate?.ablySubscriber(self, didReceiveRawLocation: locationUpdate)
             case .enhanced:
                 let message: EnhancedLocationUpdateMessage = try EnhancedLocationUpdateMessage.fromJSONString(json)
                 let locationUpdate = EnhancedLocationUpdate(location: message.location.toLocation())
                 locationUpdate.skippedLocations = message.skippedLocations.map { $0.toLocation() }
-                subscriberDelegate?.ablySubscriber(sender: self, didReceiveEnhancedLocation: locationUpdate)
+                subscriberDelegate?.ablySubscriber(self, didReceiveEnhancedLocation: locationUpdate)
             }
         } catch let error {
             guard let errorInformation = error as? ErrorInformation else {
-                subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: ErrorInformation(error: error))
+                subscriberDelegate?.ablySubscriber(self, didFailWithError: ErrorInformation(error: error))
                 
                 return
             }
             
-            subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: errorInformation)
+            subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
             
             return
         }
@@ -379,7 +379,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            publisherDelegate?.ablyPublisher(sender: self, didFailWithError: errorInformation)
+            publisherDelegate?.ablyPublisher(self, didFailWithError: errorInformation)
             
             return
         }
@@ -390,12 +390,12 @@ extension DefaultAbly: AblyPublisher {
             }
             
             if let error = error {
-                self.publisherDelegate?.ablyPublisher(sender: self, didFailWithError: error.toErrorInformation())
+                self.publisherDelegate?.ablyPublisher(self, didFailWithError: error.toErrorInformation())
                 
                 return
             }
             
-            self.publisherDelegate?.ablyPublisher(sender: self, didChangeChannelConnectionState: .online, forTrackable: trackable)
+            self.publisherDelegate?.ablyPublisher(self, didChangeChannelConnectionState: .online, forTrackable: trackable)
             completion?(.success)
         }
     }
@@ -418,7 +418,7 @@ extension DefaultAbly: AblyPublisher {
             
             channel.publish([message]) { error in
                 if let error = error {
-                    self.publisherDelegate?.ablyPublisher(sender: self, didFailWithError: error.toErrorInformation())
+                    self.publisherDelegate?.ablyPublisher(self, didFailWithError: error.toErrorInformation())
                 } else {
                     completion?(.success)
                 }
@@ -427,7 +427,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            publisherDelegate?.ablyPublisher(sender: self, didFailWithError: errorInformation)
+            publisherDelegate?.ablyPublisher(self, didFailWithError: errorInformation)
         }
     }
     

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -6,7 +6,7 @@ import Logging
 public class DefaultAbly: AblyCommon {
     
     public weak var publisherDelegate: AblyPublisherServiceDelegate?
-    public weak var subscriberDelegate: AblySubscriberServiceDelegate?
+    public weak var subscriberDelegate: AblySubscriberDelegate?
     
     private let logger: Logger
     private let client: AblySDKRealtime
@@ -179,7 +179,7 @@ public class DefaultAbly: AblyCommon {
                 sender: self,
                 didChangeConnectionState: receivedConnectionState
             )
-            self.subscriberDelegate?.subscriberService(
+            self.subscriberDelegate?.ablySubscriber(
                 sender: self,
                 didChangeClientConnectionState: receivedConnectionState
             )
@@ -221,12 +221,12 @@ public class DefaultAbly: AblyCommon {
         )
         
         // AblySubscriber delegate
-        self.subscriberDelegate?.subscriberService(sender: self, didReceivePresenceUpdate: presence)
-        self.subscriberDelegate?.subscriberService(sender: self, didChangeChannelConnectionState: presence.action.toConnectionState())
+        self.subscriberDelegate?.ablySubscriber(sender: self, didReceivePresenceUpdate: presence)
+        self.subscriberDelegate?.ablySubscriber(sender: self, didChangeChannelConnectionState: presence.action.toConnectionState())
         
         // Deleagate `Publisher` resolution if present in PresenceData
         if let resolution = data.resolution, data.type == .publisher {
-            self.subscriberDelegate?.subscriberService(sender: self, didReceiveResolution: resolution)
+            self.subscriberDelegate?.ablySubscriber(sender: self, didReceiveResolution: resolution)
         }
         
         // AblyPublisher delegate
@@ -318,7 +318,7 @@ extension DefaultAbly: AblySubscriber {
                     errorMessage: "Cannot parse message data for \(event.rawValue) event: \(String(describing: messageData))"
                 )
             )
-            subscriberDelegate?.subscriberService(sender: self, didFailWithError: errorInformation)
+            subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: errorInformation)
             
             return
         }
@@ -329,21 +329,21 @@ extension DefaultAbly: AblySubscriber {
                 let message: RawLocationUpdateMessage = try RawLocationUpdateMessage.fromJSONString(json)
                 let locationUpdate = RawLocationUpdate(location: message.location.toLocation())
                 locationUpdate.skippedLocations = message.skippedLocations.map { $0.toLocation() }
-                subscriberDelegate?.subscriberService(sender: self, didReceiveRawLocation: locationUpdate)
+                subscriberDelegate?.ablySubscriber(sender: self, didReceiveRawLocation: locationUpdate)
             case .enhanced:
                 let message: EnhancedLocationUpdateMessage = try EnhancedLocationUpdateMessage.fromJSONString(json)
                 let locationUpdate = EnhancedLocationUpdate(location: message.location.toLocation())
                 locationUpdate.skippedLocations = message.skippedLocations.map { $0.toLocation() }
-                subscriberDelegate?.subscriberService(sender: self, didReceiveEnhancedLocation: locationUpdate)
+                subscriberDelegate?.ablySubscriber(sender: self, didReceiveEnhancedLocation: locationUpdate)
             }
         } catch let error {
             guard let errorInformation = error as? ErrorInformation else {
-                subscriberDelegate?.subscriberService(sender: self, didFailWithError: ErrorInformation(error: error))
+                subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: ErrorInformation(error: error))
                 
                 return
             }
             
-            subscriberDelegate?.subscriberService(sender: self, didFailWithError: errorInformation)
+            subscriberDelegate?.ablySubscriber(sender: self, didFailWithError: errorInformation)
             
             return
         }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -5,7 +5,7 @@ import Logging
 
 public class DefaultAbly: AblyCommon {
     
-    public weak var publisherDelegate: AblyPublisherServiceDelegate?
+    public weak var publisherDelegate: AblyPublisherDelegate?
     public weak var subscriberDelegate: AblySubscriberDelegate?
     
     private let logger: Logger
@@ -175,7 +175,7 @@ public class DefaultAbly: AblyCommon {
             let receivedConnectionState = stateChange.current.toConnectionState()
             
             self.logger.debug("Connection to Ably changed. New state: \(receivedConnectionState.description)", source: String(describing: Self.self))
-            self.publisherDelegate?.publisherService(
+            self.publisherDelegate?.ablyPublisher(
                 sender: self,
                 didChangeConnectionState: receivedConnectionState
             )
@@ -230,7 +230,7 @@ public class DefaultAbly: AblyCommon {
         }
         
         // AblyPublisher delegate
-        self.publisherDelegate?.publisherService(
+        self.publisherDelegate?.ablyPublisher(
             sender: self,
             didReceivePresenceUpdate: presence,
             forTrackable: trackable,
@@ -252,7 +252,7 @@ public class DefaultAbly: AblyCommon {
             let receivedConnectionState = stateChange.current.toConnectionState()
             
             self.logger.debug("Channel state for trackable \(trackable.id) changed. New state: \(receivedConnectionState.description)", source: String(describing: Self.self))
-            self.publisherDelegate?.publisherService(sender: self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
+            self.publisherDelegate?.ablyPublisher(sender: self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
         }
     }
     
@@ -379,7 +379,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            publisherDelegate?.publisherService(sender: self, didFailWithError: errorInformation)
+            publisherDelegate?.ablyPublisher(sender: self, didFailWithError: errorInformation)
             
             return
         }
@@ -390,12 +390,12 @@ extension DefaultAbly: AblyPublisher {
             }
             
             if let error = error {
-                self.publisherDelegate?.publisherService(sender: self, didFailWithError: error.toErrorInformation())
+                self.publisherDelegate?.ablyPublisher(sender: self, didFailWithError: error.toErrorInformation())
                 
                 return
             }
             
-            self.publisherDelegate?.publisherService(sender: self, didChangeChannelConnectionState: .online, forTrackable: trackable)
+            self.publisherDelegate?.ablyPublisher(sender: self, didChangeChannelConnectionState: .online, forTrackable: trackable)
             completion?(.success)
         }
     }
@@ -418,7 +418,7 @@ extension DefaultAbly: AblyPublisher {
             
             channel.publish([message]) { error in
                 if let error = error {
-                    self.publisherDelegate?.publisherService(sender: self, didFailWithError: error.toErrorInformation())
+                    self.publisherDelegate?.ablyPublisher(sender: self, didFailWithError: error.toErrorInformation())
                 } else {
                     completion?(.success)
                 }
@@ -427,7 +427,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            publisherDelegate?.publisherService(sender: self, didFailWithError: errorInformation)
+            publisherDelegate?.ablyPublisher(sender: self, didFailWithError: errorInformation)
         }
     }
     

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -878,29 +878,29 @@ extension DefaultPublisher: LocationServiceDelegate {
     }
 }
 
-// MARK: AblyPublisherServiceDelegate
-extension DefaultPublisher: AblyPublisherServiceDelegate {
-    func publisherService(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
-        logger.debug("publisherService.didChangeChannelConnectionState. State: \(state) for trackable: \(trackable.id)", source: String(describing: Self.self))
+// MARK: AblyPublisherDelegate
+extension DefaultPublisher: AblyPublisherDelegate {
+    func ablyPublisher(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
+        logger.debug("ablyPublisher.didChangeChannelConnectionState. State: \(state) for trackable: \(trackable.id)", source: String(describing: Self.self))
         enqueue(event: AblyChannelConnectionStateChangedEvent(trackable: trackable, connectionState: state))
     }
 
-    func publisherService(sender: AblyPublisher, didFailWithError error: ErrorInformation) {
-        logger.error("publisherService.didFailWithError. Error: \(error.message)", source: "DefaultPublisher")
+    func ablyPublisher(sender: AblyPublisher, didFailWithError error: ErrorInformation) {
+        logger.error("ablyPublisher.didFailWithError. Error: \(error.message)", source: "DefaultPublisher")
         callback(event: DelegateErrorEvent(error: error))
     }
 
-    func publisherService(sender: AblyPublisher, didChangeConnectionState state: ConnectionState) {
-        logger.debug("publisherService.didChangeConnectionState. State: \(state.description)", source: String(describing: Self.self))
+    func ablyPublisher(sender: AblyPublisher, didChangeConnectionState state: ConnectionState) {
+        logger.debug("ablyPublisher.didChangeConnectionState. State: \(state.description)", source: String(describing: Self.self))
         enqueue(event: AblyClientConnectionStateChangedEvent(connectionState: state))
     }
 
-    func publisherService(sender: AblyPublisher,
+    func ablyPublisher(sender: AblyPublisher,
                           didReceivePresenceUpdate presence: Presence,
                           forTrackable trackable: Trackable,
                           presenceData: PresenceData,
                           clientId: String) {
-        logger.debug("publisherService.didReceivePresenceUpdate. Presence: \(presence), Trackable: \(trackable)",
+        logger.debug("ablyPublisher.didReceivePresenceUpdate. Presence: \(presence), Trackable: \(trackable)",
                      source: "DefaultPublisher")
         enqueue(event: PresenceUpdateEvent(trackable: trackable, presence: presence, presenceData: presenceData, clientId: clientId))
     }

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -880,22 +880,22 @@ extension DefaultPublisher: LocationServiceDelegate {
 
 // MARK: AblyPublisherDelegate
 extension DefaultPublisher: AblyPublisherDelegate {
-    func ablyPublisher(sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
+    func ablyPublisher(_ sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
         logger.debug("ablyPublisher.didChangeChannelConnectionState. State: \(state) for trackable: \(trackable.id)", source: String(describing: Self.self))
         enqueue(event: AblyChannelConnectionStateChangedEvent(trackable: trackable, connectionState: state))
     }
 
-    func ablyPublisher(sender: AblyPublisher, didFailWithError error: ErrorInformation) {
+    func ablyPublisher(_ sender: AblyPublisher, didFailWithError error: ErrorInformation) {
         logger.error("ablyPublisher.didFailWithError. Error: \(error.message)", source: "DefaultPublisher")
         callback(event: DelegateErrorEvent(error: error))
     }
 
-    func ablyPublisher(sender: AblyPublisher, didChangeConnectionState state: ConnectionState) {
+    func ablyPublisher(_ sender: AblyPublisher, didChangeConnectionState state: ConnectionState) {
         logger.debug("ablyPublisher.didChangeConnectionState. State: \(state.description)", source: String(describing: Self.self))
         enqueue(event: AblyClientConnectionStateChangedEvent(connectionState: state))
     }
 
-    func ablyPublisher(sender: AblyPublisher,
+    func ablyPublisher(_ sender: AblyPublisher,
                           didReceivePresenceUpdate presence: Presence,
                           forTrackable trackable: Trackable,
                           presenceData: PresenceData,

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -270,37 +270,37 @@ extension DefaultSubscriber {
 }
 
 extension DefaultSubscriber: AblySubscriberDelegate {
-    func ablySubscriber(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
+    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
         logger.debug("ablySubscriber.didReceivePresenceUpdate. Presence: \(presence)", source: String(describing: Self.self))
         enqueue(event: PresenceUpdateEvent(presence: presence))
     }
     
-    func ablySubscriber(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
+    func ablySubscriber(_: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
         logger.debug("ablySubscriber.didChangeClientConnectionStatus. Status: \(state)", source: String(describing: Self.self))
         enqueue(event: AblyClientConnectionStateChangedEvent(connectionState: state))
     }
     
-    func ablySubscriber(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
+    func ablySubscriber(_ sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
         logger.debug("ablySubscriber.didChangeChannelConnectionStatus. Status: \(state)", source: String(describing: Self.self))
         enqueue(event: AblyChannelConnectionStateChangedEvent(connectionState: state))
     }
 
-    func ablySubscriber(sender: AblySubscriber, didFailWithError error: ErrorInformation) {
+    func ablySubscriber(_ sender: AblySubscriber, didFailWithError error: ErrorInformation) {
         logger.error("ablySubscriber.didFailWithError. Error: \(error)", source: "DefaultSubscriber")
         callback(event: DelegateErrorEvent(error: error))
     }
 
-    func ablySubscriber(sender: AblySubscriber, didReceiveRawLocation location: LocationUpdate) {
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveRawLocation location: LocationUpdate) {
         logger.debug("ablySubscriber.didReceiveRawLocation.", source: String(describing: Self.self))
         callback(event: DelegateRawLocationReceivedEvent(locationUpdate: location))
     }
     
-    func ablySubscriber(sender: AblySubscriber, didReceiveEnhancedLocation location: LocationUpdate) {
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveEnhancedLocation location: LocationUpdate) {
         logger.debug("ablySubscriber.didReceiveEnhancedLocation.", source: String(describing: Self.self))
         callback(event: DelegateEnhancedLocationReceivedEvent(locationUpdate: location))
     }
     
-    func ablySubscriber(sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
         logger.debug("ablySubscriber.didReceiveResolution.", source: String(describing: Self.self))
         callback(event: DelegateResolutionReceivedEvent(resolution: resolution))
         callback(event: DelegateDesiredIntervalReceivedEvent(desiredInterval: resolution.desiredInterval))

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -269,39 +269,39 @@ extension DefaultSubscriber {
     }
 }
 
-extension DefaultSubscriber: AblySubscriberServiceDelegate {
-    func subscriberService(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
-        logger.debug("subscriberService.didReceivePresenceUpdate. Presence: \(presence)", source: String(describing: Self.self))
+extension DefaultSubscriber: AblySubscriberDelegate {
+    func ablySubscriber(sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
+        logger.debug("ablySubscriber.didReceivePresenceUpdate. Presence: \(presence)", source: String(describing: Self.self))
         enqueue(event: PresenceUpdateEvent(presence: presence))
     }
     
-    func subscriberService(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
-        logger.debug("subscriberService.didChangeClientConnectionStatus. Status: \(state)", source: String(describing: Self.self))
+    func ablySubscriber(sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
+        logger.debug("ablySubscriber.didChangeClientConnectionStatus. Status: \(state)", source: String(describing: Self.self))
         enqueue(event: AblyClientConnectionStateChangedEvent(connectionState: state))
     }
     
-    func subscriberService(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
-        logger.debug("subscriberService.didChangeChannelConnectionStatus. Status: \(state)", source: String(describing: Self.self))
+    func ablySubscriber(sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
+        logger.debug("ablySubscriber.didChangeChannelConnectionStatus. Status: \(state)", source: String(describing: Self.self))
         enqueue(event: AblyChannelConnectionStateChangedEvent(connectionState: state))
     }
 
-    func subscriberService(sender: AblySubscriber, didFailWithError error: ErrorInformation) {
-        logger.error("subscriberService.didFailWithError. Error: \(error)", source: "DefaultSubscriber")
+    func ablySubscriber(sender: AblySubscriber, didFailWithError error: ErrorInformation) {
+        logger.error("ablySubscriber.didFailWithError. Error: \(error)", source: "DefaultSubscriber")
         callback(event: DelegateErrorEvent(error: error))
     }
 
-    func subscriberService(sender: AblySubscriber, didReceiveRawLocation location: LocationUpdate) {
-        logger.debug("subscriberService.didReceiveRawLocation.", source: String(describing: Self.self))
+    func ablySubscriber(sender: AblySubscriber, didReceiveRawLocation location: LocationUpdate) {
+        logger.debug("ablySubscriber.didReceiveRawLocation.", source: String(describing: Self.self))
         callback(event: DelegateRawLocationReceivedEvent(locationUpdate: location))
     }
     
-    func subscriberService(sender: AblySubscriber, didReceiveEnhancedLocation location: LocationUpdate) {
-        logger.debug("subscriberService.didReceiveEnhancedLocation.", source: String(describing: Self.self))
+    func ablySubscriber(sender: AblySubscriber, didReceiveEnhancedLocation location: LocationUpdate) {
+        logger.debug("ablySubscriber.didReceiveEnhancedLocation.", source: String(describing: Self.self))
         callback(event: DelegateEnhancedLocationReceivedEvent(locationUpdate: location))
     }
     
-    func subscriberService(sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
-        logger.debug("subscriberService.didReceiveResolution.", source: String(describing: Self.self))
+    func ablySubscriber(sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
+        logger.debug("ablySubscriber.didReceiveResolution.", source: String(describing: Self.self))
         callback(event: DelegateResolutionReceivedEvent(resolution: resolution))
         callback(event: DelegateDesiredIntervalReceivedEvent(desiredInterval: resolution.desiredInterval))
     }

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -9,7 +9,7 @@ enum ClientConfigError : Error {
 
 class DefaultPublisherTests: XCTestCase {    
     var locationService: MockLocationService!
-    var ablyService: MockAblyPublisherService!
+    var ablyPublisher: MockAblyPublisher!
     var configuration: ConnectionConfiguration!
     var mapboxConfiguration: MapboxConfiguration!
     var routeProvider: MockRouteProvider!
@@ -33,7 +33,7 @@ class DefaultPublisherTests: XCTestCase {
     override func setUpWithError() throws {
         configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
         locationService = MockLocationService()
-        ablyService = MockAblyPublisherService(configuration: configuration, mode: .publish, logger: logger)
+        ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish, logger: logger)
         mapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN")
         resolutionPolicyFactory = MockResolutionPolicyFactory()
         routeProvider = MockRouteProvider()
@@ -46,7 +46,7 @@ class DefaultPublisherTests: XCTestCase {
                                      mapboxConfiguration: mapboxConfiguration,
                                      routingProfile: .driving,
                                      resolutionPolicyFactory: resolutionPolicyFactory,
-                                     ablyPublisher: ablyService,
+                                     ablyPublisher: ablyPublisher,
                                      locationService: locationService,
                                      routeProvider: routeProvider,
                                      enhancedLocationState: enhancedLocationState)
@@ -55,7 +55,7 @@ class DefaultPublisherTests: XCTestCase {
     
     // MARK: track
     func testTrack_success() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         let expectation = XCTestExpectation()
         
         // When tracking a trackable
@@ -73,9 +73,9 @@ class DefaultPublisherTests: XCTestCase {
         // It should set active trackable
         XCTAssertEqual(publisher.activeTrackable, trackable)
         
-        // It should ask ably service to track given trackable
-        XCTAssertTrue(ablyService.connectCalled)
-        XCTAssertEqual(ablyService.connectTrackableId, trackable.id)
+        // It should ask ably publisher to track given trackable
+        XCTAssertTrue(ablyPublisher.connectCalled)
+        XCTAssertEqual(ablyPublisher.connectTrackableId, trackable.id)
         
         // It should ask location service to start updating location
         XCTAssertTrue(locationService.startUpdatingLocationCalled)
@@ -91,7 +91,7 @@ class DefaultPublisherTests: XCTestCase {
     
     // MARK: track
     func testTrack_destination() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         let expectation = XCTestExpectation()
         
         let destination = LocationCoordinate(latitude: 12.3456, longitude: 56.789)
@@ -113,7 +113,7 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertEqual(routeProvider.getRouteParamDestination?.toLocationCoordinate(), destination)
     }
     func testTrack_trackableAddedEarlier() {
-        ablyService.connectCompletionHandler = { completion in completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in completion?(.success) }
         var expectation = XCTestExpectation()
         
         // When adding a new trackable
@@ -144,7 +144,7 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func test_trackCalledMultipleTimes_shouldPass() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         var expectations = [XCTestExpectation]()
         let trackMethodCalls = 5
         
@@ -168,11 +168,11 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testTrack_error_ably_service_error() {
-        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
+        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisher error"))
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
         let expectation = XCTestExpectation()
         
-        // When tracking a trackable and receive error response from AblyPublisherService
+        // When tracking a trackable and receive error response from ablyPublisher
         publisher.track(trackable: trackable) { result in
             switch result {
             case .success:
@@ -187,7 +187,7 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testTrack_successMainThread() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
 
         let expectation = XCTestExpectation()
         // onSuccess callback should be called on the main thread
@@ -205,8 +205,8 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testTrack_failureMainThread() {
-        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
+        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisher error"))
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
         let expectation = XCTestExpectation()
         
         //onError callback should be called on the main thread
@@ -225,7 +225,7 @@ class DefaultPublisherTests: XCTestCase {
     
     // MARK: add
     func testAdd_success() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         let expectation = XCTestExpectation()
         
         // When adding a trackable
@@ -242,9 +242,9 @@ class DefaultPublisherTests: XCTestCase {
         // It should NOT set active trackable
         XCTAssertNil(publisher.activeTrackable)
         
-        // It should ask ably service to track given trackable
-        XCTAssertTrue(ablyService.connectCalled)
-        XCTAssertEqual(ablyService.connectTrackableId, trackable.id)
+        // It should ask ably publisher to track given trackable
+        XCTAssertTrue(ablyPublisher.connectCalled)
+        XCTAssertEqual(ablyPublisher.connectTrackableId, trackable.id)
         
         // It should ask location service to start updating location
         XCTAssertTrue(locationService.startUpdatingLocationCalled)
@@ -258,7 +258,7 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testAdd_track_success() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 2
         
@@ -288,10 +288,10 @@ class DefaultPublisherTests: XCTestCase {
     
     func testAdd_track_error() {
         let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
         let expectation = XCTestExpectation()
         
-        // When adding a trackable and receive error response from AblyPublisherService
+        // When adding a trackable and receive error response from ablyPublisher
         publisher.add(trackable: trackable) { result in
             switch result {
             case .success:
@@ -307,7 +307,7 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testAdd_success_thread() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         let expectation = XCTestExpectation()
         // `onSuccess` callback should be called on main thread
         // Notice - in case of failure it will crash whole test suite
@@ -325,8 +325,8 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testAdd_error_thread() {
-        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
+        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisher error"))
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.failure(errorInformation)) }
         let expectation = XCTestExpectation()
         
         // `onError` callback should be called on main thread
@@ -349,8 +349,8 @@ class DefaultPublisherTests: XCTestCase {
         let wasPresent = true
         var receivedWasPresent: Bool?
         
-        ablyService.disconnectResultCompletionHandler = { completion in completion?(.success(wasPresent))}
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.disconnectResultCompletionHandler = { completion in completion?(.success(wasPresent))}
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         publisher.add(trackable: Trackable(id: "Trackable1")) { _ in }
         publisher.add(trackable: Trackable(id: "Trackable2")) { _ in }
@@ -370,11 +370,11 @@ class DefaultPublisherTests: XCTestCase {
         
         wait(for: [expectation], timeout: 5.0)
         
-        // It should ask ablyService to stop tracking
-        XCTAssertTrue(ablyService.disconnectCalled)
+        // It should ask ablyPublisher to stop tracking
+        XCTAssertTrue(ablyPublisher.disconnectCalled)
         
-        // It should ask ablyService to stop tracking given trackable
-        XCTAssertEqual(ablyService.disconnectParamTrackableId, trackable.id)
+        // It should ask ablyPublisher to stop tracking given trackable
+        XCTAssertEqual(ablyPublisher.disconnectParamTrackableId, trackable.id)
         
         // It should return correct `wasPresent` value in callback
         XCTAssertEqual(receivedWasPresent!, wasPresent)
@@ -382,14 +382,14 @@ class DefaultPublisherTests: XCTestCase {
         // It should NOT ask locationService to stop location updates as there are some tracked trackables
         XCTAssertFalse(locationService.stopUpdatingLocationCalled)
         
-        // It should notify trackables hook that trackable was removed (as it was present in AblyService)
+        // It should notify trackables hook that trackable was removed (as it was present in ablyPublisher)
         XCTAssertTrue(resolutionPolicyFactory.resolutionPolicy!.trackablesSetListener.onTrackableRemovedCalled)
         XCTAssertEqual(resolutionPolicyFactory.resolutionPolicy!.trackablesSetListener.onTrackableRemovedParamTrackable, trackable)
     }
     
     func testRemove_activeTrackable() {
-        ablyService.connectCompletionHandler = { completion in completion?(.success)}
-        ablyService.disconnectResultCompletionHandler = { handler in handler?(.success(true)) }
+        ablyPublisher.connectCompletionHandler = { completion in completion?(.success)}
+        ablyPublisher.disconnectResultCompletionHandler = { handler in handler?(.success(true)) }
         
         var expectation = XCTestExpectation(description: "Handler for `track` call")
         expectation.expectedFulfillmentCount = 1
@@ -435,8 +435,8 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testRemove_nonActiveTrackable() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
-        ablyService.disconnectResultCompletionHandler = { handler in handler?(.success(true)) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.disconnectResultCompletionHandler = { handler in handler?(.success(true)) }
         
         var expectation = XCTestExpectation(description: "Handler for `track` call")
         
@@ -476,11 +476,11 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testRemove_error() {
-        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.disconnectResultCompletionHandler = { handler in handler?(.failure(errorInformation))}
+        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisher error"))
+        ablyPublisher.disconnectResultCompletionHandler = { handler in handler?(.failure(errorInformation))}
         let expectation = XCTestExpectation()
         
-        // When removing trackable and receive error from AblyPublisherService
+        // When removing trackable and receive error from ablyPublisher
         publisher.remove(trackable: trackable) { result in
             switch result {
             case .success:
@@ -496,7 +496,7 @@ class DefaultPublisherTests: XCTestCase {
     
     
     func testRemove_success_thread() {
-        ablyService.disconnectResultCompletionHandler = { handler in handler?(.success(true))}
+        ablyPublisher.disconnectResultCompletionHandler = { handler in handler?(.success(true))}
         let expectation = XCTestExpectation()
         
         // When removing trackable `onSuccess` callback should be called on main thread
@@ -515,8 +515,8 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testRemove_error_thread() {
-        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisherService error"))
-        ablyService.disconnectResultCompletionHandler = { handler in handler?(.failure(errorInformation))}
+        let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Test AblyPublisher error"))
+        ablyPublisher.disconnectResultCompletionHandler = { handler in handler?(.failure(errorInformation))}
         
         let expectation = XCTestExpectation()
         
@@ -569,27 +569,27 @@ class DefaultPublisherTests: XCTestCase {
     
     func test_closeConnection_success() {
         let expectation = XCTestExpectation()
-        ablyService.closeResultCompletionHandler = { callback in
+        ablyPublisher.closeResultCompletionHandler = { callback in
             callback?(.success)
             expectation.fulfill()
         }
         
-        ablyService.close(presenceData: .init(type: .publisher)) { _ in }
+        ablyPublisher.close(presenceData: .init(type: .publisher)) { _ in }
         wait(for: [expectation], timeout: 5.0)
         
-        XCTAssertTrue(ablyService.closeCalled)
-        XCTAssertNotNil(ablyService.closeCompletion)
+        XCTAssertTrue(ablyPublisher.closeCalled)
+        XCTAssertNotNil(ablyPublisher.closeCompletion)
     }
     
     func test_closeConnection_failure() {
         let expectation = XCTestExpectation()
         let closeError = ErrorInformation(type: .publisherError(errorMessage: "TestError."))
-        ablyService.closeResultCompletionHandler = { callback in
+        ablyPublisher.closeResultCompletionHandler = { callback in
             callback?(.failure(closeError))
             expectation.fulfill()
         }
         
-        ablyService.close(presenceData: .init(type: .publisher)) { result in
+        ablyPublisher.close(presenceData: .init(type: .publisher)) { result in
             switch result {
             case .success:
                 XCTFail("Success not expected.")
@@ -600,8 +600,8 @@ class DefaultPublisherTests: XCTestCase {
         
         wait(for: [expectation], timeout: 5.0)
         
-        XCTAssertTrue(ablyService.closeCalled)
-        XCTAssertNotNil(ablyService.closeCompletion)
+        XCTAssertTrue(ablyPublisher.closeCalled)
+        XCTAssertNotNil(ablyPublisher.closeCompletion)
     }
     
     func testDefaultTrackableStateRetry() {
@@ -820,15 +820,15 @@ class DefaultPublisherTests: XCTestCase {
     }
     
     func testStopEventCauseImpossibilityOfEnqueueOtherEvents() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
-        ablyService.closeResultCompletionHandler = { completion in completion?(.success)}
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.closeResultCompletionHandler = { completion in completion?(.success)}
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
             mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
-            ablyPublisher: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService,
             routeProvider: routeProvider
         )

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -9,7 +9,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     let logger = Logger(label: "com.ably.tracking.DefaultPublisher_LocationServiceTests")
     
     var locationService: MockLocationService!
-    var ablyService: MockAblyPublisherService!
+    var ablyPublisher: MockAblyPublisher!
     var configuration: ConnectionConfiguration!
     var mapboxConfiguration: MapboxConfiguration!
     var resolutionPolicyFactory: MockResolutionPolicyFactory!
@@ -24,7 +24,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     override func setUpWithError() throws {
         locationService = MockLocationService()
         configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
-        ablyService = MockAblyPublisherService(configuration: configuration, mode: .publish, logger: logger)
+        ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish, logger: logger)
         mapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN")
         routeProvider = MockRouteProvider()
         resolutionPolicyFactory = MockResolutionPolicyFactory()
@@ -44,7 +44,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
             mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
-            ablyPublisher: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService,
             routeProvider: routeProvider,
             enhancedLocationState: enhancedLocationState
@@ -75,7 +75,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let expectationAddTrackable = XCTestExpectation()
         let expectationUpdateLocation = XCTestExpectation()
         
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         publisher.add(trackable: trackable) { _ in expectationAddTrackable.fulfill() }
         wait(for: [expectationAddTrackable], timeout: 5.0)
@@ -90,10 +90,10 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         XCTAssertTrue(delegate.publisherDidUpdateEnhancedLocationCalled)
         XCTAssertEqual(delegate.publisherDidUpdateEnhancedLocationParamLocation?.location, location)
         
-        // It should send row location update to AblyService
-        XCTAssertTrue(ablyService.sendEnhancedAssetLocationUpdateCalled)
-        XCTAssertEqual(ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate?.location, location)
-        XCTAssertEqual(ablyService.sendEnhancedAssetLocationUpdateParamTrackable, trackable)
+        // It should send row location update to ablyPublisher
+        XCTAssertTrue(ablyPublisher.sendEnhancedAssetLocationUpdateCalled)
+        XCTAssertEqual(ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate?.location, location)
+        XCTAssertEqual(ablyPublisher.sendEnhancedAssetLocationUpdateParamTrackable, trackable)
     }
     
     func testLocationService_didUpdateEnhancedLocation_resolution() {
@@ -116,12 +116,12 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         /**
          After tracking trackable (to trigger resolution resolve refresh)
          */
-        ablyService.connectCompletionHandler = { callback in
+        ablyPublisher.connectCompletionHandler = { callback in
             callback?(.success)
             expectation.fulfill()
         }
         
-        ablyService.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in
             completion?(.success)
         }
         
@@ -138,14 +138,14 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         _ = XCTWaiter.wait(for: [expectation, unmarkMessageAsPendingDidCallExpectation], timeout: 1.0)
         
         /**
-         It should send row location update to AblyService
+         It should send row location update to ablyPublisher
          */
-        XCTAssertTrue(ablyService.sendEnhancedAssetLocationUpdateCalled)
+        XCTAssertTrue(ablyPublisher.sendEnhancedAssetLocationUpdateCalled)
         
-        ablyService.sendEnhancedAssetLocationUpdateCalled = false
-        ablyService.sendEnhancedAssetLocationUpdateParamTrackable = nil
-        ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate = nil
-        ablyService.sendEnhancedAssetLocationUpdateParamCompletion = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateCalled = false
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamTrackable = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamCompletion = nil
         expectation = XCTestExpectation()
         
         /**
@@ -160,14 +160,14 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
         
         /**
-         It should NOT send enhanced location update to AblyService because distance between location1 and location2 is to small
+         It should NOT send enhanced location update to ablyPublisher because distance between location1 and location2 is to small
          */
-        XCTAssertFalse(ablyService.sendEnhancedAssetLocationUpdateCalled)
+        XCTAssertFalse(ablyPublisher.sendEnhancedAssetLocationUpdateCalled)
         
-        ablyService.sendEnhancedAssetLocationUpdateCalled = false
-        ablyService.sendEnhancedAssetLocationUpdateParamTrackable = nil
-        ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate = nil
-        ablyService.sendEnhancedAssetLocationUpdateParamCompletion = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateCalled = false
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamTrackable = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate = nil
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamCompletion = nil
         expectation = XCTestExpectation()
         unmarkMessageAsPendingDidCallExpectation = XCTestExpectation(description: "Trackable Unmark Message As Pending Did Call Expectation")
         
@@ -178,9 +178,9 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         _ = XCTWaiter.wait(for: [expectation, unmarkMessageAsPendingDidCallExpectation], timeout: 1.0)
         
         /**
-         It should send enhanced location update to AblyService
+         It should send enhanced location update to ablyPublisher
          */
-        XCTAssertTrue(ablyService.sendEnhancedAssetLocationUpdateCalled)
+        XCTAssertTrue(ablyPublisher.sendEnhancedAssetLocationUpdateCalled)
     }
     
     func testPublisherWillRetryOnFailureOnSendEnhancedLocationUpdate() {
@@ -193,13 +193,13 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let locationUpdate = EnhancedLocationUpdate(location: location)
         let trackable = Trackable(id: "Trackable_1")
         let trackableState = TrackableState<EnhancedLocationUpdate>()
-        let ablyService = MockAblyPublisherService(configuration: configuration, mode: .publish, logger: logger)
-        let publisher = PublisherHelper.createPublisher(ablyService: ablyService)
+        let ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish, logger: logger)
+        let publisher = PublisherHelper.createPublisher(ablyPublisher: ablyPublisher)
         
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         publisherHelper.sendLocationUpdate(
-            ablyService: ablyService,
+            ablyPublisher: ablyPublisher,
             publisher: publisher,
             locationUpdate: locationUpdate,
             trackable: trackable,
@@ -210,7 +210,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         /**
          It means that failed request (counter 1) was retried (counter 2)
          */
-        XCTAssertEqual(ablyService.sendEnhancedAssetLocationUpdateCounter, 2)
+        XCTAssertEqual(ablyPublisher.sendEnhancedAssetLocationUpdateCounter, 2)
         
     }
     
@@ -219,10 +219,10 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         var locationUpdate = EnhancedLocationUpdate(location: initialLocation)
         let trackable = Trackable(id: "Trackable_2")
         let enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
-        let ablyService = MockAblyPublisherService(configuration: configuration, mode: .publish, logger: logger)
+        let ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish, logger: logger)
         let delegate = MockPublisherDelegate()
         let publisher = PublisherHelper.createPublisher(
-            ablyService: ablyService,
+            ablyPublisher: ablyPublisher,
             enhancedLocationState: enhancedLocationState
         )
         publisher.delegate = delegate
@@ -232,10 +232,10 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
             publisherDidFailExpectation.fulfill()
         }
         
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         publisherHelper.sendLocationUpdate(
-            ablyService: ablyService,
+            ablyPublisher: ablyPublisher,
             publisher: publisher,
             locationUpdate: locationUpdate,
             trackable: trackable,
@@ -251,7 +251,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         locationUpdate = EnhancedLocationUpdate(location: newLocation)
         
         publisherHelper.sendLocationUpdate(
-            ablyService: ablyService,
+            ablyPublisher: ablyPublisher,
             publisher: publisher,
             locationUpdate: locationUpdate,
             trackable: trackable,
@@ -259,7 +259,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
             resultPolicy: .success
         )
         
-        if let sentLocationUpdate =  ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate {
+        if let sentLocationUpdate =  ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate {
             XCTAssertTrue(sentLocationUpdate.skippedLocations.contains(initialLocation))
         } else {
             XCTFail("sendEnhancedAssetLocationUpdateParamLocationUpdate is nil")
@@ -272,18 +272,18 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let nextLocation = Location(coordinate: LocationCoordinate(latitude: 2, longitude: 2))
         let nextLocationUpdate = EnhancedLocationUpdate(location: nextLocation)
         let trackable = Trackable(id: "Trackable_2")
-        let ablyService = MockAblyPublisherService(configuration: configuration, mode: .publish, logger: logger)
+        let ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish, logger: logger)
         let locationService = MockLocationService()
         let resolutionPolicyFactory = MockResolutionPolicyFactory()
         let publisher = PublisherHelper.createPublisher(
-            ablyService: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService
         )
         
         resolutionPolicyFactory.resolutionPolicy?.resolveResolutionsReturnValue = .init(accuracy: .balanced, desiredInterval: 0, minimumDisplacement: 0)
         
         let connectCompletionHandlerExpectation = XCTestExpectation(description: "Track completion handler expectation")
-        ablyService.connectCompletionHandler = { callback in
+        ablyPublisher.connectCompletionHandler = { callback in
             callback?(.success)
             connectCompletionHandlerExpectation.fulfill()
         }
@@ -292,12 +292,12 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         
         
         let sendLocationCompleteExpectation = XCTestExpectation(description: "Send Location Complete Expectation")
-        ablyService.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in
-            if ablyService.sendEnhancedAssetLocationUpdateCounter == 2 {
-                XCTAssertEqual(ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate, nextLocationUpdate)
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in
+            if ablyPublisher.sendEnhancedAssetLocationUpdateCounter == 2 {
+                XCTAssertEqual(ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate, nextLocationUpdate)
                 sendLocationCompleteExpectation.fulfill()
             } else {
-                XCTAssertEqual(ablyService.sendEnhancedAssetLocationUpdateParamLocationUpdate, locationUpdate)
+                XCTAssertEqual(ablyPublisher.sendEnhancedAssetLocationUpdateParamLocationUpdate, locationUpdate)
                 completion?(.success)
             }
         }
@@ -315,14 +315,14 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     }
     
     func testShouldSendRawMessageIfTheyAreEnabled() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
             mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
-            ablyPublisher: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService,
             routeProvider: routeProvider,
             areRawLocationsEnabled: true
@@ -336,7 +336,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let location = Location(coordinate: LocationCoordinate(latitude: 1, longitude: 2))
         let expectationDidUpdateRawLocation = self.expectation(description: "Did Update Raw Location Expectation")
         
-        ablyService.sendRawLocationParamCompletionHandler = { completion in
+        ablyPublisher.sendRawLocationParamCompletionHandler = { completion in
             completion?(.success)
             expectationDidUpdateRawLocation.fulfill()
         }
@@ -347,18 +347,18 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         )
         wait(for: [expectationDidUpdateRawLocation], timeout: 5.0)
         
-        XCTAssertTrue(ablyService.sendRawLocationWasCalled)
+        XCTAssertTrue(ablyPublisher.sendRawLocationWasCalled)
     }
     
     func testShouldNotSendRawMessageIfTheyAreDisabled() {
-        ablyService.connectCompletionHandler = { completion in  completion?(.success) }
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
             mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
-            ablyPublisher: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService,
             routeProvider: routeProvider,
             areRawLocationsEnabled: false
@@ -373,7 +373,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let expectationDidUpdateRawLocation = self.expectation(description: "Did Update Raw Location Expectation")
         expectationDidUpdateRawLocation.isInverted = true
         
-        ablyService.sendRawLocationParamCompletionHandler = { completion in
+        ablyPublisher.sendRawLocationParamCompletionHandler = { completion in
             completion?(.success)
             expectationDidUpdateRawLocation.fulfill()
         }
@@ -384,6 +384,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         )
         wait(for: [expectationDidUpdateRawLocation], timeout: 5.0)
         
-        XCTAssertFalse(ablyService.sendRawLocationWasCalled)
+        XCTAssertFalse(ablyPublisher.sendRawLocationWasCalled)
     }
 }

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -19,7 +19,7 @@ class PublisherHelper {
     }
         
     func sendLocationUpdate(
-        ablyService: MockAblyPublisherService,
+        ablyPublisher: MockAblyPublisher,
         publisher: DefaultPublisher,
         locationUpdate: EnhancedLocationUpdate,
         trackable: Trackable,
@@ -36,7 +36,7 @@ class PublisherHelper {
              Start publishing trackable
              */
             let connectCompletionHandlerExpectation = XCTestExpectation(description: "Track completion handler expectation")
-            ablyService.connectCompletionHandler = { callback in
+            ablyPublisher.connectCompletionHandler = { callback in
                 callback?(.success)
                 self.addedTrackables.append(trackable.id)
                 connectCompletionHandlerExpectation.fulfill()
@@ -51,17 +51,17 @@ class PublisherHelper {
             }
         }
         
-        ablyService.sendEnhancedAssetLocationUpdateCounter = .zero
+        ablyPublisher.sendEnhancedAssetLocationUpdateCounter = .zero
                 
         let expectationDidSendEnhancedLocation = XCTestExpectation(description: "Publisher did send enhanced location")
         
-        ablyService.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in            
+        ablyPublisher.sendEnhancedAssetLocationUpdateParamCompletionHandler = { completion in            
             switch resultPolicy {
             case .success:
                 completion?(.success)
                 expectationDidSendEnhancedLocation.fulfill()
             case .retry:
-                if ablyService.sendEnhancedAssetLocationUpdateCounter == enhancedLocationState.maxRetryCount {
+                if ablyPublisher.sendEnhancedAssetLocationUpdateCounter == enhancedLocationState.maxRetryCount {
                     completion?(.failure(error))
                 } else {
                     completion?(.success)
@@ -69,7 +69,7 @@ class PublisherHelper {
                 }
             case .fail:
                 completion?(.failure(error))
-                if ablyService.sendEnhancedAssetLocationUpdateCounter == enhancedLocationState.maxRetryCount + 1 {
+                if ablyPublisher.sendEnhancedAssetLocationUpdateCounter == enhancedLocationState.maxRetryCount + 1 {
                     expectationDidSendEnhancedLocation.fulfill()
                 }
             }
@@ -85,7 +85,7 @@ class PublisherHelper {
     }
     
     static func createPublisher(
-        ablyService: AblyPublisher,
+        ablyPublisher: AblyPublisher,
         connectionConfiguration: ConnectionConfiguration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID"),
         mapboxConfiguration: MapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN"),
         routingProfile: RoutingProfile = .driving,
@@ -100,7 +100,7 @@ class PublisherHelper {
             mapboxConfiguration: mapboxConfiguration,
             routingProfile: routingProfile,
             resolutionPolicyFactory: resolutionPolicyFactory,
-            ablyPublisher: ablyService,
+            ablyPublisher: ablyPublisher,
             locationService: locationService,
             routeProvider: routeProvider,
             enhancedLocationState: enhancedLocationState

--- a/Tests/PublisherTests/Mocks/MockAblyPublisher.swift
+++ b/Tests/PublisherTests/Mocks/MockAblyPublisher.swift
@@ -6,7 +6,7 @@ import AblyAssetTrackingInternal
 
 @testable import AblyAssetTrackingPublisher
 
-class MockAblyPublisherService: AblyPublisher {
+class MockAblyPublisher: AblyPublisher {
     
     var initConnectionConfiguration: ConnectionConfiguration?
     var initMode: AblyMode?
@@ -59,7 +59,7 @@ class MockAblyPublisherService: AblyPublisher {
     }
 
     var wasDelegateSet: Bool = false
-    var publisherDelegate: AblyPublisherServiceDelegate? {
+    var publisherDelegate: AblyPublisherDelegate? {
         didSet { wasDelegateSet = true }
     }
 

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -4,7 +4,7 @@ import AblyAssetTrackingCore
 @testable import AblyAssetTrackingSubscriber
 
 class DefaultSubscriberTests: XCTestCase {
-    private var ablySubscriber: MockAblySubscriberService!
+    private var ablySubscriber: MockAblySubscriber!
     private var subscriber: DefaultSubscriber!
     
     private let configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
@@ -12,7 +12,7 @@ class DefaultSubscriberTests: XCTestCase {
     
     override func setUpWithError() throws {
         let trackableId: String = "Trackable-\(UUID().uuidString)"
-        ablySubscriber = MockAblySubscriberService(configuration: configuration, mode: .subscribe, logger: logger)
+        ablySubscriber = MockAblySubscriber(configuration: configuration, mode: .subscribe, logger: logger)
         
         subscriber = DefaultSubscriber(
             ablySubscriber: ablySubscriber,

--- a/Tests/SubscriberTests/Mocks/MockAblySubscriber.swift
+++ b/Tests/SubscriberTests/Mocks/MockAblySubscriber.swift
@@ -4,9 +4,9 @@ import AblyAssetTrackingInternal
 import Logging
 @testable import AblyAssetTrackingSubscriber
 
-class MockAblySubscriberService: AblySubscriber {
+class MockAblySubscriber: AblySubscriber {
     var wasDelegateSet: Bool = false
-    var subscriberDelegate: AblySubscriberServiceDelegate? {
+    var subscriberDelegate: AblySubscriberDelegate? {
         didSet { wasDelegateSet = true }
     }
     


### PR DESCRIPTION
This removes remaining references to the word `Service`, which seem to be references to a class name that has now been changed. See commit messages for more details.