### PR TITLE
Fail subscriber if malformed message received

### DIFF
--- a/.sourcery-InternalMocks.yml
+++ b/.sourcery-InternalMocks.yml
@@ -1,5 +1,6 @@
 sources:
   - Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+  - Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
 templates:
   - Sourcery/templates/AutoMockable.stencil
 output:

--- a/.sourcery-SubscriberMocks.yml
+++ b/.sourcery-SubscriberMocks.yml
@@ -1,0 +1,9 @@
+sources:
+  - Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
+templates:
+  - Sourcery/templates/AutoMockable.stencil
+output:
+  Tests/SubscriberTests/Mocks/GeneratedMocks.swift
+args:
+  autoMockableImports:
+    - AblyAssetTrackingSubscriber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ and then manually merge the delta contents in to the main change log (where `v1.
 
 We use [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to generate mocks for the protocols in the following files:
 
+- `Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift`
 - `Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift`
 - `Sources/AblyAssetTrackingSubscriber/Subscriber.swift`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,11 @@ and then manually merge the delta contents in to the main change log (where `v1.
 
 ## Generating mocks
 
-We use [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to generate mocks for the protocols in the file `Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift`. At the time of writing, there is no way to automatically generate these mocks as part of the SPM build process, so when you update this file you’ll need to manually run the command `Scripts/generate-mocks.sh`.
+We use [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to generate mocks for the protocols in the following files:
+
+- `Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift`
+- `Sources/AblyAssetTrackingSubscriber/Subscriber.swift`
+
+At the time of writing, there is no way to automatically generate these mocks as part of the SPM build process, so when you update these files you’ll need to manually run the command `Scripts/generate-mocks.sh`.
 
 When [Swift package plugins](https://developer.apple.com/videos/play/wwdc2022/110359/) get introduced in Swift 5.6, we might be able to generate these mocks automatically.

--- a/Scripts/generate-mocks.sh
+++ b/Scripts/generate-mocks.sh
@@ -15,3 +15,4 @@ run_sourcery () {
 }
 
 run_sourcery "InternalMocks"
+run_sourcery "SubscriberMocks"

--- a/Sources/AblyAssetTrackingCore/ErrorCode.swift
+++ b/Sources/AblyAssetTrackingCore/ErrorCode.swift
@@ -1,0 +1,9 @@
+/**
+ The range of `ErrorInformation.code` values that represent an error in the Ably Asset Tracking SDK. These codes are canonically defined by https://github.com/ably/ably-asset-tracking-common/tree/main/specification#error-codes.
+ */
+public enum ErrorCode: Int {
+    /**
+     The SDK received a message in an unexpected format. This is treated as a fatal protocol error and the transport will be closed with a failure.
+     */
+    case invalidMessage = 100001
+}

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyCommon.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyCommon.swift
@@ -59,7 +59,7 @@ public protocol AblyCommon {
      - Parameter presenceData:  The data that will be send via the presence channel.
      - Parameter completion:    The closure that will be called when disconnecting completes. If something goes wrong it will be called with `error` object.
      */
-    func disconnect(trackableId: String, presenceData: PresenceData, completion: @escaping ResultHandler<Bool>)
+    func disconnect(trackableId: String, presenceData: PresenceData?, completion: @escaping ResultHandler<Bool>)
     
     /**
      Cleanups and closes all the connected channels and their presence. In the end closes Ably connection.

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
@@ -2,6 +2,7 @@ import Foundation
 import AblyAssetTrackingCore
 import CoreLocation
 
+//sourcery: AutoMockable
 public protocol AblySubscriberDelegate: AnyObject {
     /**
      Tells the delegate that `Ably` client connection state changed.

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -313,11 +313,7 @@ extension DefaultAbly: AblySubscriber {
     
     private func handleLocationUpdateResponse(forEvent event: EventName, messageData: Any?) {
         guard let json = messageData as? String else {
-            let errorInformation = ErrorInformation(
-                type: .subscriberError(
-                    errorMessage: "Cannot parse message data for \(event.rawValue) event: \(String(describing: messageData))"
-                )
-            )
+            let errorInformation = ErrorInformation(code: ErrorCode.invalidMessage.rawValue, statusCode: 400, message: "Received a non-string message for \(event.rawValue) event: \(String(describing: messageData))", cause: nil, href: nil)
             subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
             
             return
@@ -338,7 +334,8 @@ extension DefaultAbly: AblySubscriber {
             }
         } catch let error {
             guard let errorInformation = error as? ErrorInformation else {
-                subscriberDelegate?.ablySubscriber(self, didFailWithError: ErrorInformation(error: error))
+                let errorInformation = ErrorInformation(code: ErrorCode.invalidMessage.rawValue, statusCode: 400, message: "Received a malformed message for \(event.rawValue) event", cause: error, href: nil)
+                subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
                 
                 return
             }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -110,14 +110,21 @@ public class DefaultAbly: AblyCommon {
         }
     }
     
-    public func disconnect(trackableId: String, presenceData: PresenceData, completion: @escaping ResultHandler<Bool>) {
+    public func disconnect(trackableId: String, presenceData: PresenceData?, completion: @escaping ResultHandler<Bool>) {
         guard let channelToRemove = channels[trackableId] else {
             completion(.success(false))
             
             return
         }
         
-        channelToRemove.presence.leave(presenceDataJSON(data: presenceData)) { [weak self] error in
+        let presenceDataJSON: Any?
+        if let presenceData = presenceData {
+            presenceDataJSON = self.presenceDataJSON(data: presenceData)
+        } else {
+            presenceDataJSON = nil
+        }
+        
+        channelToRemove.presence.leave(presenceDataJSON) { [weak self] error in
             guard let error = error else {
                 self?.logger.debug("Left channel [id: \(trackableId)] presence successfully", source: String(describing: Self.self))
                 

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -51,4 +51,5 @@ public protocol AblySDKAuth {
     func authorize(_ callback: @escaping ARTTokenDetailsCallback)
 }
 
+//sourcery: AutoMockable
 public protocol AblySDKEventListener {}

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -212,6 +212,11 @@ extension DefaultSubscriber {
     }
     
     private func handleConnectionStateChange() {
+        if currentTrackableConnectionState == .failed {
+            logger.debug("Ignoring state change since state is already .failed", source: String(describing: Self.self))
+            return
+        }
+        
         var newConnectionState: ConnectionState = .offline
         
         switch receivedAblyClientConnectionState {

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -265,6 +265,12 @@ extension DefaultSubscriber {
             logger.error("invalidMessage error received, emitting failed connection status: \(event.error)")
             currentTrackableConnectionState = .failed
             callback(event: .delegateConnectionStatusChanged(.init(status: .failed)))
+
+            ablySubscriber.disconnect(trackableId: trackableId, presenceData: nil) { [trackableId] error in
+                if case .failure(let error) = error {
+                    logger.error("Failed to disconnect trackable (\(trackableId)) after receiving invalid message. Error: \(error)")
+                }
+            }
         }
     }
 

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
@@ -12,6 +12,7 @@ extension DefaultSubscriber {
         case ablyConnectionClosed(AblyConnectionClosedEvent)
         case ablyClientConnectionStateChanged(AblyClientConnectionStateChangedEvent)
         case ablyChannelConnectionStateChanged(AblyChannelConnectionStateChangedEvent)
+        case ablyError(AblyErrorEvent)
         
         struct StartEvent {
             let resultHandler: ResultHandler<Void>
@@ -40,6 +41,10 @@ extension DefaultSubscriber {
         
         struct AblyChannelConnectionStateChangedEvent {
             let connectionState: ConnectionState
+        }
+        
+        struct AblyErrorEvent {
+            let error: ErrorInformation
         }
     }
     

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
@@ -2,6 +2,7 @@ import CoreLocation
 import Foundation
 import AblyAssetTrackingCore
 
+//sourcery: AutoMockable
 public protocol SubscriberDelegate: AnyObject {
     /**
      Called when `Subscriber` spot any (location, network or permissions) error

--- a/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
+++ b/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
@@ -332,4 +332,61 @@ class DefaultAblyTests: XCTestCase {
         XCTAssertEqual(presence.enterCallbackCallsCount, 1)
         XCTAssertEqual(auth.authorizeCallsCount, 1)
     }
+    
+    func test_subscribeForRawEvents_whenItReceivesMalformedLocationMessageData_itCallsDidFailOnSubscriberDelegate_withInvalidMessageError() {
+        let data = "{\"something\": \"somethingElse\"}"
+        test_subscribeForRawEvents_whenItReceivesThisLocationMessageData_itCallsDidFailOnSubscriberDelegate_withInvalidMessageError(data: data)
+    }
+    
+    func test_subscribeForRawEvents_whenItReceivesNonStringLocationMessageData_itCallsDidFailOnSubscriberDelegate_withInvalidMessageError() {
+        let data = ["something":"somethingElse"]
+        test_subscribeForRawEvents_whenItReceivesThisLocationMessageData_itCallsDidFailOnSubscriberDelegate_withInvalidMessageError(data: data)
+    }
+    
+    func test_subscribeForRawEvents_whenItReceivesThisLocationMessageData_itCallsDidFailOnSubscriberDelegate_withInvalidMessageError(data: Any) {
+        let presence = AblySDKRealtimePresenceMock()
+
+        presence.enterCallbackClosure = { _, callback in callback?(nil) }
+        
+        let channel = AblySDKRealtimeChannelMock()
+        
+        channel.subscribeCallbackClosure = { _, callback in
+            let message = ARTMessage(name: nil, data: data)
+            callback(message)
+            
+            return AblySDKEventListenerMock()
+        }
+        
+        channel.presence = presence
+        
+        let channels = AblySDKRealtimeChannelsMock()
+        channels.getChannelForTrackingIdOptionsReturnValue = channel
+        
+        let realtime = AblySDKRealtimeMock()
+        realtime.channels = channels
+        
+        let factory = AblySDKRealtimeFactoryMock()
+        factory.createWithConfigurationReturnValue = realtime
+        
+        let connectionConfiguration = ConnectionConfiguration { _, callback in
+            callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
+        }
+        
+        let trackableId = "abc"
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logger: logger)
+        ably.connect(trackableId: trackableId, presenceData: .init(type: .subscriber), useRewind: false) { _ in }
+        
+        let subscriberDelegate = AblySubscriberDelegateMock()
+        ably.subscriberDelegate = subscriberDelegate
+        
+        let expectation = expectation(description: "Wait for subscriber delegate to receive error callback")
+        subscriberDelegate.ablySubscriberDidFailWithErrorClosure = { _, error in
+            XCTAssertEqual(error.code, ErrorCode.invalidMessage.rawValue)
+            expectation.fulfill()
+        }
+        
+        ably.subscribeForRawEvents(trackableId: trackableId)
+        
+        waitForExpectations(timeout: 10)
+    }
 }

--- a/Tests/InternalTests/Mocks/GeneratedMocks.swift
+++ b/Tests/InternalTests/Mocks/GeneratedMocks.swift
@@ -75,6 +75,9 @@ class AblySDKConnectionMock: AblySDKConnection {
     }
 
 }
+class AblySDKEventListenerMock: AblySDKEventListener {
+
+}
 class AblySDKRealtimeMock: AblySDKRealtime {
     var channels: AblySDKRealtimeChannels {
         get { return underlyingChannels }

--- a/Tests/InternalTests/Mocks/GeneratedMocks.swift
+++ b/Tests/InternalTests/Mocks/GeneratedMocks.swift
@@ -381,3 +381,125 @@ class AblySDKRealtimePresenceMock: AblySDKRealtimePresence {
     }
 
 }
+class AblySubscriberDelegateMock: AblySubscriberDelegate {
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidChangeClientConnectionStateCallsCount = 0
+    var ablySubscriberDidChangeClientConnectionStateCalled: Bool {
+        return ablySubscriberDidChangeClientConnectionStateCallsCount > 0
+    }
+    var ablySubscriberDidChangeClientConnectionStateReceivedArguments: (sender: AblySubscriber, state: ConnectionState)?
+    var ablySubscriberDidChangeClientConnectionStateReceivedInvocations: [(sender: AblySubscriber, state: ConnectionState)] = []
+    var ablySubscriberDidChangeClientConnectionStateClosure: ((AblySubscriber, ConnectionState) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
+        ablySubscriberDidChangeClientConnectionStateCallsCount += 1
+        ablySubscriberDidChangeClientConnectionStateReceivedArguments = (sender: sender, state: state)
+        ablySubscriberDidChangeClientConnectionStateReceivedInvocations.append((sender: sender, state: state))
+        ablySubscriberDidChangeClientConnectionStateClosure?(sender, state)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidChangeChannelConnectionStateCallsCount = 0
+    var ablySubscriberDidChangeChannelConnectionStateCalled: Bool {
+        return ablySubscriberDidChangeChannelConnectionStateCallsCount > 0
+    }
+    var ablySubscriberDidChangeChannelConnectionStateReceivedArguments: (sender: AblySubscriber, state: ConnectionState)?
+    var ablySubscriberDidChangeChannelConnectionStateReceivedInvocations: [(sender: AblySubscriber, state: ConnectionState)] = []
+    var ablySubscriberDidChangeChannelConnectionStateClosure: ((AblySubscriber, ConnectionState) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
+        ablySubscriberDidChangeChannelConnectionStateCallsCount += 1
+        ablySubscriberDidChangeChannelConnectionStateReceivedArguments = (sender: sender, state: state)
+        ablySubscriberDidChangeChannelConnectionStateReceivedInvocations.append((sender: sender, state: state))
+        ablySubscriberDidChangeChannelConnectionStateClosure?(sender, state)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidReceivePresenceUpdateCallsCount = 0
+    var ablySubscriberDidReceivePresenceUpdateCalled: Bool {
+        return ablySubscriberDidReceivePresenceUpdateCallsCount > 0
+    }
+    var ablySubscriberDidReceivePresenceUpdateReceivedArguments: (sender: AblySubscriber, presence: Presence)?
+    var ablySubscriberDidReceivePresenceUpdateReceivedInvocations: [(sender: AblySubscriber, presence: Presence)] = []
+    var ablySubscriberDidReceivePresenceUpdateClosure: ((AblySubscriber, Presence) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
+        ablySubscriberDidReceivePresenceUpdateCallsCount += 1
+        ablySubscriberDidReceivePresenceUpdateReceivedArguments = (sender: sender, presence: presence)
+        ablySubscriberDidReceivePresenceUpdateReceivedInvocations.append((sender: sender, presence: presence))
+        ablySubscriberDidReceivePresenceUpdateClosure?(sender, presence)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidFailWithErrorCallsCount = 0
+    var ablySubscriberDidFailWithErrorCalled: Bool {
+        return ablySubscriberDidFailWithErrorCallsCount > 0
+    }
+    var ablySubscriberDidFailWithErrorReceivedArguments: (sender: AblySubscriber, error: ErrorInformation)?
+    var ablySubscriberDidFailWithErrorReceivedInvocations: [(sender: AblySubscriber, error: ErrorInformation)] = []
+    var ablySubscriberDidFailWithErrorClosure: ((AblySubscriber, ErrorInformation) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didFailWithError error: ErrorInformation) {
+        ablySubscriberDidFailWithErrorCallsCount += 1
+        ablySubscriberDidFailWithErrorReceivedArguments = (sender: sender, error: error)
+        ablySubscriberDidFailWithErrorReceivedInvocations.append((sender: sender, error: error))
+        ablySubscriberDidFailWithErrorClosure?(sender, error)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidReceiveEnhancedLocationCallsCount = 0
+    var ablySubscriberDidReceiveEnhancedLocationCalled: Bool {
+        return ablySubscriberDidReceiveEnhancedLocationCallsCount > 0
+    }
+    var ablySubscriberDidReceiveEnhancedLocationReceivedArguments: (sender: AblySubscriber, locationUpdate: LocationUpdate)?
+    var ablySubscriberDidReceiveEnhancedLocationReceivedInvocations: [(sender: AblySubscriber, locationUpdate: LocationUpdate)] = []
+    var ablySubscriberDidReceiveEnhancedLocationClosure: ((AblySubscriber, LocationUpdate) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveEnhancedLocation locationUpdate: LocationUpdate) {
+        ablySubscriberDidReceiveEnhancedLocationCallsCount += 1
+        ablySubscriberDidReceiveEnhancedLocationReceivedArguments = (sender: sender, locationUpdate: locationUpdate)
+        ablySubscriberDidReceiveEnhancedLocationReceivedInvocations.append((sender: sender, locationUpdate: locationUpdate))
+        ablySubscriberDidReceiveEnhancedLocationClosure?(sender, locationUpdate)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidReceiveRawLocationCallsCount = 0
+    var ablySubscriberDidReceiveRawLocationCalled: Bool {
+        return ablySubscriberDidReceiveRawLocationCallsCount > 0
+    }
+    var ablySubscriberDidReceiveRawLocationReceivedArguments: (sender: AblySubscriber, locationUpdate: LocationUpdate)?
+    var ablySubscriberDidReceiveRawLocationReceivedInvocations: [(sender: AblySubscriber, locationUpdate: LocationUpdate)] = []
+    var ablySubscriberDidReceiveRawLocationClosure: ((AblySubscriber, LocationUpdate) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveRawLocation locationUpdate: LocationUpdate) {
+        ablySubscriberDidReceiveRawLocationCallsCount += 1
+        ablySubscriberDidReceiveRawLocationReceivedArguments = (sender: sender, locationUpdate: locationUpdate)
+        ablySubscriberDidReceiveRawLocationReceivedInvocations.append((sender: sender, locationUpdate: locationUpdate))
+        ablySubscriberDidReceiveRawLocationClosure?(sender, locationUpdate)
+    }
+
+    //MARK: - ablySubscriber
+
+    var ablySubscriberDidReceiveResolutionCallsCount = 0
+    var ablySubscriberDidReceiveResolutionCalled: Bool {
+        return ablySubscriberDidReceiveResolutionCallsCount > 0
+    }
+    var ablySubscriberDidReceiveResolutionReceivedArguments: (sender: AblySubscriber, resolution: Resolution)?
+    var ablySubscriberDidReceiveResolutionReceivedInvocations: [(sender: AblySubscriber, resolution: Resolution)] = []
+    var ablySubscriberDidReceiveResolutionClosure: ((AblySubscriber, Resolution) -> Void)?
+
+    func ablySubscriber(_ sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
+        ablySubscriberDidReceiveResolutionCallsCount += 1
+        ablySubscriberDidReceiveResolutionReceivedArguments = (sender: sender, resolution: resolution)
+        ablySubscriberDidReceiveResolutionReceivedInvocations.append((sender: sender, resolution: resolution))
+        ablySubscriberDidReceiveResolutionClosure?(sender, resolution)
+    }
+
+}

--- a/Tests/PublisherTests/Mocks/MockAblyPublisher.swift
+++ b/Tests/PublisherTests/Mocks/MockAblyPublisher.swift
@@ -51,7 +51,7 @@ class MockAblyPublisher: AblyPublisher {
     var disconnectParamTrackableId: String?
     var disconnectParamResultHandler: ResultHandler<Bool>?
     var disconnectResultCompletionHandler: ((ResultHandler<Bool>?) -> Void)?
-    func disconnect(trackableId: String, presenceData: PresenceData, completion: @escaping ResultHandler<Bool>) {
+    func disconnect(trackableId: String, presenceData: PresenceData?, completion: @escaping ResultHandler<Bool>) {
         disconnectCalled = true
         disconnectParamTrackableId = trackableId
         disconnectParamResultHandler = completion

--- a/Tests/SubscriberTests/Mocks/GeneratedMocks.swift
+++ b/Tests/SubscriberTests/Mocks/GeneratedMocks.swift
@@ -1,0 +1,134 @@
+// Generated using Sourcery 1.8.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
+
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
+import AblyAssetTrackingSubscriber
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class SubscriberDelegateMock: SubscriberDelegate {
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidFailWithErrorCallsCount = 0
+    var subscriberSenderDidFailWithErrorCalled: Bool {
+        return subscriberSenderDidFailWithErrorCallsCount > 0
+    }
+    var subscriberSenderDidFailWithErrorReceivedArguments: (sender: Subscriber, error: ErrorInformation)?
+    var subscriberSenderDidFailWithErrorReceivedInvocations: [(sender: Subscriber, error: ErrorInformation)] = []
+    var subscriberSenderDidFailWithErrorClosure: ((Subscriber, ErrorInformation) -> Void)?
+
+    func subscriber(sender: Subscriber, didFailWithError error: ErrorInformation) {
+        subscriberSenderDidFailWithErrorCallsCount += 1
+        subscriberSenderDidFailWithErrorReceivedArguments = (sender: sender, error: error)
+        subscriberSenderDidFailWithErrorReceivedInvocations.append((sender: sender, error: error))
+        subscriberSenderDidFailWithErrorClosure?(sender, error)
+    }
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidUpdateEnhancedLocationCallsCount = 0
+    var subscriberSenderDidUpdateEnhancedLocationCalled: Bool {
+        return subscriberSenderDidUpdateEnhancedLocationCallsCount > 0
+    }
+    var subscriberSenderDidUpdateEnhancedLocationReceivedArguments: (sender: Subscriber, locationUpdate: LocationUpdate)?
+    var subscriberSenderDidUpdateEnhancedLocationReceivedInvocations: [(sender: Subscriber, locationUpdate: LocationUpdate)] = []
+    var subscriberSenderDidUpdateEnhancedLocationClosure: ((Subscriber, LocationUpdate) -> Void)?
+
+    func subscriber(sender: Subscriber, didUpdateEnhancedLocation locationUpdate: LocationUpdate) {
+        subscriberSenderDidUpdateEnhancedLocationCallsCount += 1
+        subscriberSenderDidUpdateEnhancedLocationReceivedArguments = (sender: sender, locationUpdate: locationUpdate)
+        subscriberSenderDidUpdateEnhancedLocationReceivedInvocations.append((sender: sender, locationUpdate: locationUpdate))
+        subscriberSenderDidUpdateEnhancedLocationClosure?(sender, locationUpdate)
+    }
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidUpdateRawLocationCallsCount = 0
+    var subscriberSenderDidUpdateRawLocationCalled: Bool {
+        return subscriberSenderDidUpdateRawLocationCallsCount > 0
+    }
+    var subscriberSenderDidUpdateRawLocationReceivedArguments: (sender: Subscriber, locationUpdate: LocationUpdate)?
+    var subscriberSenderDidUpdateRawLocationReceivedInvocations: [(sender: Subscriber, locationUpdate: LocationUpdate)] = []
+    var subscriberSenderDidUpdateRawLocationClosure: ((Subscriber, LocationUpdate) -> Void)?
+
+    func subscriber(sender: Subscriber, didUpdateRawLocation locationUpdate: LocationUpdate) {
+        subscriberSenderDidUpdateRawLocationCallsCount += 1
+        subscriberSenderDidUpdateRawLocationReceivedArguments = (sender: sender, locationUpdate: locationUpdate)
+        subscriberSenderDidUpdateRawLocationReceivedInvocations.append((sender: sender, locationUpdate: locationUpdate))
+        subscriberSenderDidUpdateRawLocationClosure?(sender, locationUpdate)
+    }
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidUpdateResolutionCallsCount = 0
+    var subscriberSenderDidUpdateResolutionCalled: Bool {
+        return subscriberSenderDidUpdateResolutionCallsCount > 0
+    }
+    var subscriberSenderDidUpdateResolutionReceivedArguments: (sender: Subscriber, resolution: Resolution)?
+    var subscriberSenderDidUpdateResolutionReceivedInvocations: [(sender: Subscriber, resolution: Resolution)] = []
+    var subscriberSenderDidUpdateResolutionClosure: ((Subscriber, Resolution) -> Void)?
+
+    func subscriber(sender: Subscriber, didUpdateResolution resolution: Resolution) {
+        subscriberSenderDidUpdateResolutionCallsCount += 1
+        subscriberSenderDidUpdateResolutionReceivedArguments = (sender: sender, resolution: resolution)
+        subscriberSenderDidUpdateResolutionReceivedInvocations.append((sender: sender, resolution: resolution))
+        subscriberSenderDidUpdateResolutionClosure?(sender, resolution)
+    }
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidUpdateDesiredIntervalCallsCount = 0
+    var subscriberSenderDidUpdateDesiredIntervalCalled: Bool {
+        return subscriberSenderDidUpdateDesiredIntervalCallsCount > 0
+    }
+    var subscriberSenderDidUpdateDesiredIntervalReceivedArguments: (sender: Subscriber, interval: Double)?
+    var subscriberSenderDidUpdateDesiredIntervalReceivedInvocations: [(sender: Subscriber, interval: Double)] = []
+    var subscriberSenderDidUpdateDesiredIntervalClosure: ((Subscriber, Double) -> Void)?
+
+    func subscriber(sender: Subscriber, didUpdateDesiredInterval interval: Double) {
+        subscriberSenderDidUpdateDesiredIntervalCallsCount += 1
+        subscriberSenderDidUpdateDesiredIntervalReceivedArguments = (sender: sender, interval: interval)
+        subscriberSenderDidUpdateDesiredIntervalReceivedInvocations.append((sender: sender, interval: interval))
+        subscriberSenderDidUpdateDesiredIntervalClosure?(sender, interval)
+    }
+
+    //MARK: - subscriber
+
+    var subscriberSenderDidChangeAssetConnectionStatusCallsCount = 0
+    var subscriberSenderDidChangeAssetConnectionStatusCalled: Bool {
+        return subscriberSenderDidChangeAssetConnectionStatusCallsCount > 0
+    }
+    var subscriberSenderDidChangeAssetConnectionStatusReceivedArguments: (sender: Subscriber, status: ConnectionState)?
+    var subscriberSenderDidChangeAssetConnectionStatusReceivedInvocations: [(sender: Subscriber, status: ConnectionState)] = []
+    var subscriberSenderDidChangeAssetConnectionStatusClosure: ((Subscriber, ConnectionState) -> Void)?
+
+    func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
+        subscriberSenderDidChangeAssetConnectionStatusCallsCount += 1
+        subscriberSenderDidChangeAssetConnectionStatusReceivedArguments = (sender: sender, status: status)
+        subscriberSenderDidChangeAssetConnectionStatusReceivedInvocations.append((sender: sender, status: status))
+        subscriberSenderDidChangeAssetConnectionStatusClosure?(sender, status)
+    }
+
+}

--- a/Tests/SubscriberTests/Mocks/MockAblySubscriber.swift
+++ b/Tests/SubscriberTests/Mocks/MockAblySubscriber.swift
@@ -87,11 +87,13 @@ class MockAblySubscriber: AblySubscriber {
     
     var disconnectCalled: Bool = false
     var disconnectParamTrackableId: String?
+    var disconnectParamPresenceData: PresenceData?
     var disconnectParamResultHandler: ResultHandler<Bool>?
     var disconnectResultCompletionHandler: ((ResultHandler<Bool>?) -> Void)?
-    func disconnect(trackableId: String, presenceData: PresenceData, completion: @escaping ResultHandler<Bool>) {
+    func disconnect(trackableId: String, presenceData: PresenceData?, completion: @escaping ResultHandler<Bool>) {
         disconnectCalled = true
         disconnectParamTrackableId = trackableId
+        disconnectParamPresenceData = presenceData
         disconnectParamResultHandler = completion
         disconnectResultCompletionHandler?(completion)
     }

--- a/Tests/SystemTests/Mocks/SubscriberGeneratedMocks.swift
+++ b/Tests/SystemTests/Mocks/SubscriberGeneratedMocks.swift
@@ -1,0 +1,1 @@
+../../SubscriberTests/Mocks/GeneratedMocks.swift

--- a/Tests/SystemTests/SubscriberSystemTests.swift
+++ b/Tests/SystemTests/SubscriberSystemTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import AblyAssetTrackingSubscriber
+import Ably
+
+class SubscriberSystemTests: XCTestCase {
+    func test_whenSubscriberReceivesMalformedMessageDataFromAbly_itEmitsAFailedConnectionStatus() {
+        let trackingId = UUID().uuidString
+        
+        let delegate = SubscriberDelegateMock()
+        
+        let subscriberStartExpectation = expectation(description: "Subscriber successfully starts")
+        let subscriber = SubscriberFactory.subscribers()
+            .trackingId(trackingId)
+            .connection(ConnectionConfiguration(apiKey: Secrets.ablyApiKey, clientId: UUID().uuidString))
+            .delegate(delegate)
+            .start { result in
+                switch result {
+                case .success: subscriberStartExpectation.fulfill()
+                case let .failure(error): XCTFail("Subscriber failed to start: \(error)")
+                }
+            }
+        
+        waitForExpectations(timeout: 10)
+        
+        let delegateDidFailWithErrorCalledExpectation = expectation(description: "Subscriber’s delegate receives didFailWithError")
+        delegate.subscriberSenderDidFailWithErrorClosure = { _, error in
+            XCTAssertEqual(error.code, ErrorCode.invalidMessage.rawValue)
+            delegateDidFailWithErrorCalledExpectation.fulfill()
+        }
+        
+        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeAssetConnectionStatus")
+        delegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, status in
+            XCTAssertEqual(status, .failed)
+            delegateDidChangeAssetConnectionStatusExpectation.fulfill()
+        }
+        
+        let ably = ARTRealtime(key: Secrets.ablyApiKey)
+        let channel = ably.channels.get("tracking:\(trackingId)")
+        
+        let publishExpectation = expectation(description: "Message published to channel")
+        channel.publish("enhanced", data: "{\"something\": \"anotherThing\"}") { error in
+            if let error = error {
+                XCTFail("Failed to publish message: \(error)")
+            } else {
+                publishExpectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        let subscriberStopExpectation = expectation(description: "Wait for subscriber to stop")
+        subscriber?.stop(completion: { result in
+            switch result {
+            case .success:
+                subscriberStopExpectation.fulfill()
+            case let .failure(errorInfo):
+                XCTFail("Failed to stop subscriber, with error \(errorInfo)")
+            }
+        })
+        waitForExpectations(timeout: 10)
+    }
+}


### PR DESCRIPTION
This makes `DefaultSubscriber` fail with an [invalid message error](https://github.com/ably/ably-asset-tracking-common/tree/main/specification#error-codes) if it receives a malformed location update. The behaviour is roughly as in https://github.com/ably/ably-asset-tracking-android/issues/691. See commit messages for more details.