### PR TITLE
Allow users to get a list of trackables

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/MapViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/MapViewModel.swift
@@ -148,6 +148,8 @@ class MapViewModel: ObservableObject {
 }
 
 extension MapViewModel: PublisherDelegate {
+    func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>) {}
+    
     func publisher(sender: Publisher, didFailWithError error: ErrorInformation) {
         updateErrorInfo(error)
     }

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -42,9 +42,14 @@ class DefaultPublisher: Publisher {
     private var subscribers: [Trackable: Set<Subscriber>]
     private var resolutions: [Trackable: Resolution]
     private var locationEngineResolution: Resolution
-    private var trackables: Set<Trackable>
+    private var trackables: Set<Trackable> {
+        didSet {
+            notifyTrackablesChanged(trackables: trackables)
+        }
+    }
+    
     private var constantLocationEngineResolution: Resolution?
-
+    
     private var lastEnhancedLocations: [Trackable: Location]
     private var lastEnhancedTimestamps: [Trackable: Double]
     private var lastRawLocations: [Trackable: Location]
@@ -849,6 +854,13 @@ extension DefaultPublisher {
         performOnMainThread { [weak self] in
             guard let self = self else { return }
             self.delegate?.publisher(sender: self, didUpdateResolution: event.resolution)
+        }
+    }
+    
+    private func notifyTrackablesChanged(trackables: Set<Trackable>) {
+        performOnMainThread { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.publisher(sender: self, didChangeTrackables: trackables)
         }
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -38,4 +38,13 @@ public protocol PublisherDelegate: AnyObject {
         - resolution: Most recent resolution.
     */
     func publisher(sender: Publisher, didUpdateResolution resolution: Resolution)
+    
+    /**
+     Called whenever the trackables list of a `Publisher` instance changes
+     
+     - Parameters:
+        - sender: `Publisher` instance.
+        - trackables: a list of trackables that are currently present on the `sender`'s instance
+    */
+    func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>)
 }

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -44,7 +44,7 @@ public protocol PublisherDelegate: AnyObject {
      
      - Parameters:
         - sender: `Publisher` instance.
-        - trackables: a list of trackables that are currently present on the `sender`'s instance
+        - trackables: a set of trackables that are currently present on the `sender`'s instance
     */
     func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>)
 }

--- a/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
+++ b/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
@@ -56,7 +56,7 @@ class MockPublisherDelegate: PublisherDelegate {
     var publisherDidChangeTrackablesCallback: (() -> Void)?
     func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>) {
         publisherDidChangeTrackablesCalled = true
-        publisherDidUpdateResolutionParamSender = sender
+        publisherDidChangeTrackablesParamSender = sender
         publisherDidChangeTrackablesParamTrackables = trackables
         publisherDidChangeTrackablesCallback?()
     }

--- a/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
+++ b/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
@@ -49,4 +49,15 @@ class MockPublisherDelegate: PublisherDelegate {
         publisherDidUpdateResolutionParamResolution = resolution
         publisherDidUpdateResolutionCallback?()
     }
+    
+    var publisherDidChangeTrackablesCalled: Bool = false
+    var publisherDidChangeTrackablesParamSender: Publisher?
+    var publisherDidChangeTrackablesParamTrackables: Set<Trackable>?
+    var publisherDidChangeTrackablesCallback: (() -> Void)?
+    func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>) {
+        publisherDidChangeTrackablesCalled = true
+        publisherDidUpdateResolutionParamSender = sender
+        publisherDidChangeTrackablesParamTrackables = trackables
+        publisherDidChangeTrackablesCallback?()
+    }
 }

--- a/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
+++ b/Tests/SystemTests/PublisherAuthenticationSystemTests.swift
@@ -211,21 +211,3 @@ class PublisherAuthenticationSystemTests: XCTestCase {
         XCTAssertTrue(hasRequestedUpdatedToken)
     }
 }
-
-private class PublisherTestDelegate: PublisherDelegate {
-    func publisher(sender: Publisher, didFailWithError error: ErrorInformation) {
-        return
-    }
-    
-    func publisher(sender: Publisher, didUpdateEnhancedLocation location: EnhancedLocationUpdate) {
-        return
-    }
-    
-    func publisher(sender: Publisher, didChangeConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
-        return
-    }
-    
-    func publisher(sender: Publisher, didUpdateResolution resolution: Resolution) {
-        return
-    }
-}

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -224,13 +224,3 @@ extension PublisherAndSubscriberSystemTests: SubscriberDelegate {
         didUpdateResolutionExpectation.fulfill()
     }
 }
-
-extension PublisherAndSubscriberSystemTests: PublisherDelegate {
-    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didFailWithError error: ErrorInformation) {}
-    
-    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didUpdateEnhancedLocation location: EnhancedLocationUpdate) {}
-    
-    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didChangeConnectionState state: ConnectionState, forTrackable trackable: Trackable) {}
-    
-    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didUpdateResolution resolution: Resolution) {}
-}


### PR DESCRIPTION
Currently it's impossible to know which trackables are tracked by a publisher.
This PR adds a delegate method that returns a list of trackables that are currently added to a publisher whenever this list changes (similarly to how it works on Android).

Resolves: [336](https://github.com/ably/ably-asset-tracking-swift/issues/336)