### PR TITLE
Handle connection resume exception

### DIFF
--- a/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -135,8 +135,7 @@ public class DefaultAbly: AblyCommon {
             completion(.success(false))
             return
         }
-        
-        
+
         do {
             try performChannelOperationWithRetry(channel: channelToRemove, operation: { channel in
                 try disconnectChannel(channel: channel, presenceData: presenceData!)
@@ -373,7 +372,6 @@ public class DefaultAbly: AblyCommon {
            try performChannelOperationWithRetry(channel: channel) { channel in
                updatePresenceData(channel: channel, presenceData: presenceData, completion)
             }
-            completion?(.success)
         } catch AblyError.connectionError(let errorInfo){
             completion?(.failure(errorInfo.toErrorInformation()))
         }catch{
@@ -519,7 +517,6 @@ extension DefaultAbly: AblyPublisher {
                     completion?(.success)
                 }
             }
-            completion?(.success)
 
         } catch AblyError.connectionError(let errorInfo){
             completion?(.failure(errorInfo.toErrorInformation()))

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -150,7 +150,7 @@ public class DefaultAbly: AblyCommon {
         }catch AblyError.connectionError(let errorInfo){
             completion(.failure(errorInfo.toErrorInformation()))
         }catch{
-            
+            completion(.failure(ErrorInformation(error: AblyError.connectionError(errorInfo: ARTErrorInfo.create(withCode: 100_000, message: "Unknown error while disconnecting")))))
         }
     }
     

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -178,7 +178,7 @@ public class DefaultAbly: AblyCommon {
         }
         
          channel.presence.leave(presenceDataJSON){ errorInfo in
-             //This to maintain clousure signature
+             //This is to maintain closure signature
              do{
                  try completion(errorInfo)
              }catch{}
@@ -188,14 +188,12 @@ public class DefaultAbly: AblyCommon {
     
     private func detachFromChannel(channel:AblySDKRealtimeChannel, completion : @escaping (ARTErrorInfo?) throws -> Void) {
         channel.detach { errorInfo in
-            //maintain clousure signature
             do{
                 try completion(errorInfo)
             }catch{}
         }
     }
 
-    //This function is to be documented and must be invoked from a background thread
     private func performChannelOperationWithRetry(channel:AblySDKRealtimeChannel, operation : (AblySDKRealtimeChannel) throws ->Void) throws {
       do {
           logHandler?.w(message: "Trying to perform an operation on a suspended channel \(channel.name), waiting for the channel to be reconnected", error: nil)
@@ -207,7 +205,7 @@ public class DefaultAbly: AblyCommon {
                logHandler?.w(message: "Connection resume failed for channel \(channel), waiting for the channel to be reconnected",
                        error: errorInfo
                )
-               //We can try another time
+
                do {
                    try waitForChannelReconnection(channel: channel)
                    try operation(channel)
@@ -232,7 +230,6 @@ public class DefaultAbly: AblyCommon {
         blockingDispatchGroup.enter()
         channel.on { stateChange in
             if (stateChange.current.toConnectionState() == .online){
-                //i want to exit here or when this operation timed out
                 blockingDispatchGroup.leave()
             }
             

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -139,7 +139,7 @@ public class DefaultAbly: AblyCommon {
                     return
                 }
 
-                try disconnectChannel(channel: channel, presenceData: presenceData)
+                disconnectChannel(channel: channel, presenceData: presenceData)
             })
             
             channels.removeValue(forKey: trackableId)
@@ -151,7 +151,7 @@ public class DefaultAbly: AblyCommon {
         }
     }
     
-    private func disconnectChannel(channel:AblySDKRealtimeChannel, presenceData: PresenceData) throws{
+    private func disconnectChannel(channel:AblySDKRealtimeChannel, presenceData: PresenceData){
         leavePresence(channel: channel, presenceData: presenceData) { leaveError in
             if let leaveError = leaveError {
                 throw InternalError.connectionError(errorInfo: leaveError)

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -236,7 +236,11 @@ public class DefaultAbly: AblyCommon {
         }
         let timeout: DispatchTime = .now() + .seconds(timeoutInMs / 1000)
         
-        blockingDispatchGroup.wait(timeout: timeout)
+        let result = blockingDispatchGroup.wait(timeout: timeout)
+        
+        if (result == .timedOut){
+            throw AblyError.connectionError(errorInfo: ARTErrorInfo.create(withCode: 100000, message: "Timeout was thrown when waiting for channel to attach"))
+        }
     }
     
     

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -225,7 +225,7 @@ public class DefaultAbly: AblyCommon {
 
     /**
      * Waits for the [channel] to change to the [ChannelState.attached] state.
-     * If this doesn't happen during the next [timeoutInMilliseconds] milliseconds, then an exception is thrown.
+     * If this doesn't happen during the next [timeoutInMs] milliseconds, then an exception is thrown.
      */
     private func waitForChannelReconnection(channel:AblySDKRealtimeChannel, timeoutInMs:Int = 10_000) throws{
         guard channel.state.toConnectionState() != .online else{

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -502,6 +502,7 @@ extension DefaultAbly: AblyPublisher {
                     completion?(.success)
                 }
             }
+            completion?(.success)
 
         } catch AblyError.connectionError(let errorInfo){
             completion?(.failure(errorInfo.toErrorInformation()))

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -204,7 +204,7 @@ public class DefaultAbly: AblyCommon {
                logHandler?.w(message: "Connection resume failed for channel \(channel), waiting for the channel to be reconnected",
                        error: errorInfo
                )
-               do { try waitForChannelReconnection(channel: channel)
+               do {
                    try waitForChannelReconnection(channel: channel)
                    try operation(channel)
                }catch InternalError.connectionError(let secondError){

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -191,6 +191,11 @@ public class DefaultAbly: AblyCommon {
         }
     }
 
+    /**
+     * Performs the [operation] and if a "connection resume" exception is thrown it waits for the [channel] to
+     * reconnect and retries the [operation], otherwise it rethrows the exception. If the [operation] fails for
+     * the second time the exception is rethrown no matter if it was the "connection resume" exception or not.
+     */
     private func performChannelOperationWithRetry(channel:AblySDKRealtimeChannel, operation : (AblySDKRealtimeChannel) throws ->Void) throws {
       do {
           logHandler?.w(message: "Trying to perform an operation on a suspended channel \(channel.name), waiting for the channel to be reconnected", error: nil)
@@ -218,7 +223,10 @@ public class DefaultAbly: AblyCommon {
       }
     }
 
-    
+    /**
+     * Waits for the [channel] to change to the [ChannelState.attached] state.
+     * If this doesn't happen during the next [timeoutInMilliseconds] milliseconds, then an exception is thrown.
+     */
     private func waitForChannelReconnection(channel:AblySDKRealtimeChannel, timeoutInMs:Int = 10_000) throws{
         guard channel.state.toConnectionState() != .online else{
             return

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -198,17 +198,13 @@ public class DefaultAbly: AblyCommon {
      */
     private func performChannelOperationWithRetry(channel:AblySDKRealtimeChannel, operation : (AblySDKRealtimeChannel) throws ->Void) throws {
       do {
-          logHandler?.w(message: "Trying to perform an operation on a suspended channel \(channel.name), waiting for the channel to be reconnected", error: nil)
-          try waitForChannelReconnection(channel: channel)
           try operation(channel)
       } catch  AblyError.connectionError(let errorInfo) {
            if errorInfo.isConnectionResumeException(){
-            
                logHandler?.w(message: "Connection resume failed for channel \(channel), waiting for the channel to be reconnected",
                        error: errorInfo
                )
-
-               do {
+               do { try waitForChannelReconnection(channel: channel)
                    try waitForChannelReconnection(channel: channel)
                    try operation(channel)
                }catch AblyError.connectionError(let secondError){

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -138,7 +138,11 @@ public class DefaultAbly: AblyCommon {
 
         do {
             try performChannelOperationWithRetry(channel: channelToRemove, operation: { channel in
-                try disconnectChannel(channel: channel, presenceData: presenceData!)
+                guard let presenceData = presenceData else {
+                    return
+                }
+
+                try disconnectChannel(channel: channel, presenceData: presenceData)
             })
             
             channels.removeValue(forKey: trackableId)

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -19,9 +19,6 @@ public class DefaultAbly: AblyCommon {
     let mode: AblyMode
     
     private var channels: [String: AblySDKRealtimeChannel] = [:]
-    
-    //This queue is intended to serialze async operations
-    private let operationQueue = DispatchQueue(label: "com.ably.tracking")
 
     public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, mode: AblyMode, logHandler: AblyLogHandler?) {
         self.logHandler = logHandler

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -192,7 +192,7 @@ public class DefaultAbly: AblyCommon {
       }
     }
 
-    private func waitForChannelReconnection(channel:ARTRealtimeChannel, timeoutInMs:Int32 = 10_000) throws{
+    private func waitForChannelReconnection(channel:ARTRealtimeChannel, timeoutInMs:Int = 10_000) throws{
         guard channel.state.toConnectionState() != .online else{
             return
         }
@@ -203,7 +203,9 @@ public class DefaultAbly: AblyCommon {
                 blockingDispatchGroup.leave()
             }
         }
-        blockingDispatchGroup.wait(timeout: .now() + Int((timeoutInMs / 1000)))
+        let timeout: DispatchTime = .now() + .seconds(timeoutInMs / 1000)
+        
+        blockingDispatchGroup.wait(timeout: timeout)
     }
     
     
@@ -516,8 +518,7 @@ fileprivate extension ConnectionConfiguration {
 
 extension ARTErrorInfo {
     func isConnectionResumeException() -> Bool {
-        guard let errorInfo == toErrorInformation() else { return false }
-
+        let errorInfo = toErrorInformation()
         return  errorInfo.message == "Connection resume failed" && errorInfo.code == 50000 && errorInfo.statusCode == 500
     }
 }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
@@ -31,7 +31,20 @@ struct AblyCocoaSDKRealtimeChannels: AblySDKRealtimeChannels {
 }
 
 struct AblyCocoaSDKRealtimeChannel: AblySDKRealtimeChannel {
+    
     fileprivate let channel: ARTRealtimeChannel
+    
+    var name: String {
+        get {
+            return channel.name
+        }
+    }
+    
+    var state: ARTRealtimeChannelState {
+        get {
+            return channel.state
+        }
+    }
     
     var presence: AblySDKRealtimePresence {
         return AblyCocoaSDKRealtimePresence(presence: channel.presence)

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -22,6 +22,8 @@ public protocol AblySDKRealtimeChannels {
 
 //sourcery: AutoMockable
 public protocol AblySDKRealtimeChannel {
+    var name : String { get }
+    var state: ARTRealtimeChannelState { get }
     var presence: AblySDKRealtimePresence { get }
     @discardableResult func subscribe(_ name: String, callback: @escaping ARTMessageCallback) -> AblySDKEventListener?
     func unsubscribe()

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -309,7 +309,7 @@ extension DefaultPublisher {
 
             switch result {
             case .success:
-                self?.enqueue(event: .presenceJoinedSuccessfully(.init(trackable: trackable) { [weak self] _ in
+                self?.enqueue(event: .presenceJoinedSuccessfully(.init(trackable: trackable) {_ in
                     completion()
                 }))
             case .failure(let error):
@@ -319,7 +319,7 @@ extension DefaultPublisher {
     }
     // MARK: Add trackable
     private func performAddTrackableEvent(_ event: Event.AddTrackableEvent) {
-        performAddOrTrack(event.trackable, resultHandler: event.resultHandler) {
+        performAddOrTrack(event.trackable, resultHandler: event.resultHandler) { [weak self] in
             self?.callback(value: Void(), handler: event.resultHandler)
         }
     }

--- a/Tests/InternalTests/Mocks/GeneratedMocks.swift
+++ b/Tests/InternalTests/Mocks/GeneratedMocks.swift
@@ -110,6 +110,16 @@ class AblySDKRealtimeMock: AblySDKRealtime {
 
 }
 class AblySDKRealtimeChannelMock: AblySDKRealtimeChannel {
+    var name: String {
+        get { return underlyingName }
+        set(value) { underlyingName = value }
+    }
+    var underlyingName: String!
+    var state: ARTRealtimeChannelState {
+        get { return underlyingState }
+        set(value) { underlyingState = value }
+    }
+    var underlyingState: ARTRealtimeChannelState!
     var presence: AblySDKRealtimePresence {
         get { return underlyingPresence }
         set(value) { underlyingPresence = value }


### PR DESCRIPTION
Handles channel connection resume exception by retrying operation one more time

Closes https://github.com/ably/ably-asset-tracking-swift/issues/347

Note to reviewers: I will create a separate task for writing tests for this