### PR TITLE
Allow user to specify Ably environment

### DIFF
--- a/Sources/AblyAssetTrackingCore/Configuration/ConnectionConfiguration.swift
+++ b/Sources/AblyAssetTrackingCore/Configuration/ConnectionConfiguration.swift
@@ -18,6 +18,11 @@ public class ConnectionConfiguration {
     public let apiKey: String?
     public let clientId: String?
     public let authCallback: AuthCallback?
+    /**
+     * For development or non-default production environments.
+     * Allows a non-default Ably environment to be used such as 'sandbox'.
+     */
+    public var environment: String?
     
     /**
      Connect to Ably using basic authentication (API Key)

--- a/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
@@ -23,6 +23,10 @@ extension ConnectionConfiguration {
         
         clientOptions.addAgent("ably-asset-tracking-swift", version: Version.libraryVersion)
         
+        if let environment = environment {
+            clientOptions.environment = environment
+        }
+        
         return clientOptions
     }
     


### PR DESCRIPTION
This adds an `environment` property to ConnectionConfiguration. API and documentation taken from ably-asset-tracking-android@c52a9a5.

Closes #326.