### PR TITLE
Fix some incorrect conversions between milliseconds and seconds in the subscriber example app

### DIFF
--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
@@ -30,7 +30,7 @@ class MapViewController: UIViewController {
     private let locationAnimator: LocationAnimator
     private var subscriber: Subscriber?
     private var errors: [ErrorInformation] = []
-    private var locationUpdateInterval: TimeInterval = .zero
+    private var locationUpdateIntervalInMilliseconds: Double = .zero
 
     private var currentResolution: Resolution?
     private var resolutionDebounceTimer: Timer?
@@ -50,7 +50,7 @@ class MapViewController: UIViewController {
         
         self.trackingId = trackingId
         self.locationAnimator = DefaultLocationAnimator()
-        self.locationUpdateInterval = resolution.desiredInterval
+        self.locationUpdateIntervalInMilliseconds = resolution.desiredInterval
 
         let viewControllerType = MapViewController.self
         super.init(nibName: String(describing: viewControllerType), bundle: Bundle(for: viewControllerType))
@@ -291,7 +291,7 @@ extension MapViewController: SubscriberDelegate {
 
     func subscriber(sender: Subscriber, didUpdateEnhancedLocation locationUpdate: LocationUpdate) {
         if animationSwitch.isOn {
-            locationAnimator.animateLocationUpdate(location: locationUpdate, expectedIntervalBetweenLocationUpdatesInMilliseconds: locationUpdateInterval / 1000.0)
+            locationAnimator.animateLocationUpdate(location: locationUpdate, expectedIntervalBetweenLocationUpdatesInMilliseconds: locationUpdateIntervalInMilliseconds)
         } else {
             updateTruckAnnotation(position: locationUpdate.location.toPosition())
             scrollToReceivedLocation(position: locationUpdate.location.toPosition())
@@ -311,6 +311,6 @@ extension MapViewController: SubscriberDelegate {
     }
     
     func subscriber(sender: Subscriber, didUpdateDesiredInterval interval: Double) {
-        locationUpdateInterval = interval
+        locationUpdateIntervalInMilliseconds = interval
     }
 }

--- a/README.md
+++ b/README.md
@@ -186,9 +186,17 @@ locationAnimator.subscribeForInfrequentlyUpdatingPosition { position in
 ```
 
 ```swift
+var locationUpdateIntervalInMilliseconds: Double
+
+func subscriber(sender: Subscriber, didUpdateDesiredInterval interval: Double) {
+    locationUpdateIntervalInMilliseconds = interval
+}
+```
+
+```swift
 // Feed animator with location changes from the `Subscriber SDK`
 func subscriber(sender: Subscriber, didUpdateEnhancedLocation locationUpdate: LocationUpdate) {
-    locationAnimator.animateLocationUpdate(location: locationUpdate, interval: locationUpdateInterval / 1000.0)
+    locationAnimator.animateLocationUpdate(location: locationUpdate, expectedIntervalBetweenLocationUpdatesInMilliseconds: locationUpdateIntervalInMilliseconds)
 }
 ```
 


### PR DESCRIPTION
We had assumed that things that were seconds were milliseconds and vice-versa.

I don’t really understand why we’ve created an API that forces us into this conversion dance, but I’ve created #378 for that.

The updated usage example in the `README` is taken from the SubscriberExample app.

I discovered this whilst investigating #375 (when using animation, the asset position on map quickly drifts far from received asset positions), but this change alone doesn’t fix that issue.