### PR TITLE
Expose publisher presence information to subscriber

### DIFF
--- a/Examples/SubscriberExample/Sources/Screens/Map/Helpers/DescriptionsHelper.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/Helpers/DescriptionsHelper.swift
@@ -40,8 +40,8 @@ class DescriptionsHelper {
     }
     
     enum AssetState {
-        case connectionState(_: ConnectionState)
-        case none
+        case connectionState(_: ConnectionState?)
+        case subscriberPresence(isPresent: Bool?)
     }
     
     // MARK: - AssetConnectionState
@@ -49,16 +49,28 @@ class DescriptionsHelper {
         static func getDescriptionAndColor(for state: AssetState) -> (desc: String, color: UIColor) {
             switch state {
             case .connectionState(let connectionState):
-                switch connectionState {
-                case .online:
-                    return ("online", .systemGreen)
-                case .offline:
-                    return ("offline", .systemRed)
-                case .failed:
-                    return ("failed", .systemRed)
+                if let connectionState = connectionState {
+                    switch connectionState {
+                    case .online:
+                        return ("online", .systemGreen)
+                    case .offline:
+                        return ("offline", .systemRed)
+                    case .failed:
+                        return ("failed", .systemRed)
+                    }
+                } else {
+                    return ("The asset connection status is not determined", .black)
                 }
-            case .none:
-                return ("The asset connection status is not determined", .black)
+            case .subscriberPresence(let isPresent):
+                if let isPresent = isPresent {
+                    if isPresent {
+                        return ("present", .systemGreen)
+                    } else {
+                        return ("not present", .systemRed)
+                    }
+                } else {
+                    return ("The publisher’s presence is not determined", .black)
+                }
             }
         }
     }

--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
@@ -13,6 +13,7 @@ private struct MapConstraints {
 class MapViewController: UIViewController {
     // MARK: - Outlets
     @IBOutlet private weak var assetStatusLabel: UILabel!
+    @IBOutlet private weak var publisherPresenceLabel: UILabel!
     @IBOutlet private weak var animationSwitch: UISwitch!
     @IBOutlet private weak var mapView: MKMapView!
     @IBOutlet private weak var subscriberResolutionAccuracyLabel: UILabel!
@@ -64,7 +65,8 @@ class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Tracking \(trackingId)"
-        assetStatusLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .none).desc
+        assetStatusLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .connectionState(nil)).desc
+        publisherPresenceLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .subscriberPresence(isPresent: nil)).desc
         setupSubscriber()
         setupMapView()
         setupControlsBehaviour()
@@ -304,6 +306,12 @@ extension MapViewController: SubscriberDelegate {
         let statusDescAndColor = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .connectionState(status))
         assetStatusLabel.textColor = statusDescAndColor.color
         assetStatusLabel.text = statusDescAndColor.desc
+    }
+    
+    func subscriber(sender: Subscriber, didUpdatePublisherPresence isPresent: Bool) {
+        let presenceDescAndColor = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .subscriberPresence(isPresent: isPresent))
+        publisherPresenceLabel.textColor = presenceDescAndColor.color
+        publisherPresenceLabel.text = presenceDescAndColor.desc
     }
     
     func subscriber(sender: Subscriber, didUpdateResolution resolution: Resolution) {

--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.xib
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,6 +14,7 @@
                 <outlet property="animationSwitch" destination="sen-Ab-9Ef" id="Xsh-ao-DIm"/>
                 <outlet property="assetStatusLabel" destination="O8V-GW-qu9" id="IjD-RY-pGF"/>
                 <outlet property="mapView" destination="8rN-ex-fYt" id="hlP-fp-bxE"/>
+                <outlet property="publisherPresenceLabel" destination="gKY-OE-RLB" id="qZy-NJ-KmH"/>
                 <outlet property="publisherResolutionAccuracyLabel" destination="75F-iX-0cS" id="v5r-rs-N1h"/>
                 <outlet property="publisherResolutionIntervalLabel" destination="rBH-Yg-gSz" id="abV-eu-De2"/>
                 <outlet property="publisherResolutionMinDisplacementlabel" destination="jON-hJ-qnE" id="gse-eA-xP7"/>
@@ -35,26 +36,26 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rlU-Db-8yK">
-                    <rect key="frame" x="16" y="87" width="398" height="1"/>
+                    <rect key="frame" x="16" y="108" width="398" height="1"/>
                     <color key="backgroundColor" systemColor="separatorColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="IzB-Zn-fbl"/>
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Animation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sMc-4x-IXA">
-                    <rect key="frame" x="16" y="100" width="65" height="17"/>
+                    <rect key="frame" x="16" y="121" width="65" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sen-Ab-9Ef">
-                    <rect key="frame" x="349" y="93" width="51" height="31"/>
+                    <rect key="frame" x="349" y="114" width="51" height="31"/>
                 </switch>
                 <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="8rN-ex-fYt">
-                    <rect key="frame" x="0.0" y="272" width="414" height="590"/>
+                    <rect key="frame" x="0.0" y="293" width="414" height="569"/>
                 </mapView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Otn-da-B2G">
-                    <rect key="frame" x="16" y="129" width="398" height="1"/>
+                    <rect key="frame" x="16" y="150" width="398" height="1"/>
                     <color key="backgroundColor" systemColor="separatorColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="bnd-9j-Ab0"/>
@@ -66,8 +67,20 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The publisher is" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uou-sk-KPp">
+                    <rect key="frame" x="16" y="79" width="103" height="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="not present" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKY-OE-RLB">
+                    <rect key="frame" x="124" y="79" width="74.5" height="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Mc8-Qu-FXa" userLabel="Subscriber resolution (stackview)">
-                    <rect key="frame" x="20" y="140" width="374" height="56"/>
+                    <rect key="frame" x="20" y="161" width="374" height="56"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscriber's requested resolution" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6f-Zg-mfA">
                             <rect key="frame" x="0.0" y="0.0" width="374" height="16"/>
@@ -133,7 +146,7 @@
                     </subviews>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sNt-A4-1tH" userLabel="Publisher resolution (stack view)">
-                    <rect key="frame" x="20" y="206" width="374" height="56"/>
+                    <rect key="frame" x="20" y="227" width="374" height="56"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Publishers's calculated resolution" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kQw-io-hzr">
                             <rect key="frame" x="0.0" y="0.0" width="374" height="16"/>
@@ -211,9 +224,10 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sen-Ab-9Ef" secondAttribute="trailing" constant="16" id="744-4O-y5a"/>
                 <constraint firstItem="sen-Ab-9Ef" firstAttribute="centerY" secondItem="sMc-4x-IXA" secondAttribute="centerY" id="7w1-zk-e0A"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="8rN-ex-fYt" secondAttribute="bottom" id="7w8-hO-WYp"/>
-                <constraint firstItem="rlU-Db-8yK" firstAttribute="top" secondItem="lrm-Ub-YVy" secondAttribute="bottom" constant="12" id="ADx-4C-rbQ"/>
                 <constraint firstItem="Mc8-Qu-FXa" firstAttribute="top" secondItem="Otn-da-B2G" secondAttribute="bottom" constant="10" id="EOO-BA-gmZ"/>
+                <constraint firstItem="rlU-Db-8yK" firstAttribute="top" secondItem="Uou-sk-KPp" secondAttribute="bottom" constant="12" id="JC3-m7-Kb9"/>
                 <constraint firstItem="sNt-A4-1tH" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="SdA-0F-iSj"/>
+                <constraint firstItem="gKY-OE-RLB" firstAttribute="leading" secondItem="Uou-sk-KPp" secondAttribute="trailing" constant="5" id="TDb-fU-qYk"/>
                 <constraint firstItem="sNt-A4-1tH" firstAttribute="top" secondItem="Mc8-Qu-FXa" secondAttribute="bottom" constant="10" id="W15-8J-aSw"/>
                 <constraint firstItem="rlU-Db-8yK" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="XtK-q7-tde"/>
                 <constraint firstItem="8rN-ex-fYt" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="c9s-dr-upz"/>
@@ -222,8 +236,11 @@
                 <constraint firstItem="sMc-4x-IXA" firstAttribute="top" secondItem="rlU-Db-8yK" secondAttribute="bottom" constant="12" id="lGu-SY-hhH"/>
                 <constraint firstItem="lrm-Ub-YVy" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="o5F-4U-5RM"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Mc8-Qu-FXa" secondAttribute="trailing" constant="20" id="oDL-Gv-OTZ"/>
+                <constraint firstItem="Uou-sk-KPp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="oZp-h2-KZ7"/>
                 <constraint firstItem="Otn-da-B2G" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="r0o-fv-Wvp"/>
                 <constraint firstItem="8rN-ex-fYt" firstAttribute="top" secondItem="sNt-A4-1tH" secondAttribute="bottom" constant="10" id="rGC-NM-T7N"/>
+                <constraint firstItem="Uou-sk-KPp" firstAttribute="top" secondItem="lrm-Ub-YVy" secondAttribute="bottom" constant="4" id="s4u-Af-nHZ"/>
+                <constraint firstItem="gKY-OE-RLB" firstAttribute="centerY" secondItem="Uou-sk-KPp" secondAttribute="centerY" id="tMh-m7-1Y9"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sNt-A4-1tH" secondAttribute="trailing" constant="20" id="vTY-2R-3UL"/>
                 <constraint firstAttribute="trailing" secondItem="Otn-da-B2G" secondAttribute="trailing" id="xV1-EB-6Iz"/>
             </constraints>

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -28,6 +28,7 @@ class DefaultSubscriber: Subscriber {
     private var receivedAblyChannelConnectionState: ConnectionState = .offline
     private var currentTrackableConnectionState: ConnectionState = .offline
     private var isPublisherOnline: Bool = false
+    private var lastEmittedIsPublisherOnline: Bool?
     
     weak var delegate: SubscriberDelegate?
 
@@ -143,6 +144,7 @@ extension DefaultSubscriber {
             case .delegateRawLocationReceived(let event): delegate.subscriber(sender: self, didUpdateRawLocation: event.locationUpdate)
             case .delegateResolutionReceived(let event): delegate.subscriber(sender: self, didUpdateResolution: event.resolution)
             case .delegateDesiredIntervalReceived(let event): delegate.subscriber(sender: self, didUpdateDesiredInterval: event.desiredInterval)
+            case .delegateUpdatedPublisherPresence(let event): delegate.subscriber(sender: self, didUpdatePublisherPresence: event.isPresent)
             }
         }
     }
@@ -195,6 +197,11 @@ extension DefaultSubscriber {
             isPublisherOnline = true
         } else if event.presence.action.isLeaveOrAbsent {
             isPublisherOnline = false
+        }
+        
+        if isPublisherOnline != lastEmittedIsPublisherOnline {
+            lastEmittedIsPublisherOnline = isPublisherOnline
+            callback(event: .delegateUpdatedPublisherPresence(.init(isPresent: isPublisherOnline)))
         }
     }
     

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
@@ -57,6 +57,7 @@ extension DefaultSubscriber {
         case delegateResolutionReceived(DelegateResolutionReceivedEvent)
         case delegateDesiredIntervalReceived(DelegateDesiredIntervalReceivedEvent)
         case delegateConnectionStatusChanged(DelegateConnectionStatusChangedEvent)
+        case delegateUpdatedPublisherPresence(DelegateUpdatedPublisherPresenceEvent)
         
         struct DelegateErrorEvent {
             let error: ErrorInformation
@@ -80,6 +81,10 @@ extension DefaultSubscriber {
         
         struct DelegateConnectionStatusChangedEvent {
             let status: ConnectionState
+        }
+        
+        struct DelegateUpdatedPublisherPresenceEvent {
+            let isPresent: Bool
         }
     }
 }

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
@@ -53,6 +53,17 @@ public protocol SubscriberDelegate: AnyObject {
         - status: Updated connection status.
      */
     func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState)
+    
+    /**
+     Called when the `Subscriber` receives updated information about whether the publisher is present.
+     
+     > Note: This API is experimental and may change or be removed in the future.
+     
+     - Parameters:
+        - sender: `Subscriber` instance.
+        - isPresent: Whether the publisher is present.
+     */
+    func subscriber(sender: Subscriber, didUpdatePublisherPresence isPresent: Bool)
 }
 
 public extension SubscriberDelegate {
@@ -70,4 +81,9 @@ public extension SubscriberDelegate {
      Default implementation to make this method `optional`
     */
     func subscriber(sender: Subscriber, didUpdateDesiredInterval interval: Double) {}
+    
+    /**
+     Default implementation to make this method `optional`
+    */
+    func subscriber(sender: Subscriber, didUpdatePublisherPresence isPresent: Bool) {}
 }

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AblyAssetTrackingCore
+@testable import AblyAssetTrackingInternal
 @testable import AblyAssetTrackingSubscriber
 
 class DefaultSubscriberTests: XCTestCase {
@@ -361,5 +362,36 @@ class DefaultSubscriberTests: XCTestCase {
         ablySubscriber.subscriberDelegate?.ablySubscriber(ablySubscriber, didChangeChannelConnectionState: .online)
         
         RunLoop.main.run(until: Date() + 0.5)
+    }
+    
+    func test_whenItReceivesAPublisherPresentPresenceAction_itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresentTrue() {
+        test_whenItReceivesAPublisherPresenceAction(.present, itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresent: true)
+    }
+    
+    func test_whenItReceivesAPublisherEnterPresenceAction_itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresentTrue() {
+        test_whenItReceivesAPublisherPresenceAction(.enter, itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresent: true)
+    }
+    
+    func test_whenItReceivesAPublisherLeavePresenceAction_itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresentFalse() {
+        test_whenItReceivesAPublisherPresenceAction(.leave, itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresent: false)
+    }
+    
+    func test_whenItReceivesAPublisherAbsentPresenceAction_itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresentFalse() {
+        test_whenItReceivesAPublisherPresenceAction(.absent, itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresent: false)
+    }
+    
+    func test_whenItReceivesAPublisherPresenceAction(_ presenceAction: PresenceAction, itCallsDidUpdatePublisherPresenceOnDelegate_withIsPresent expectedIsPresent: Bool) {
+        let delegate = SubscriberDelegateMock()
+        subscriber.delegate = delegate
+        
+        let delegateDidFailWithErrorCalledExpectation = expectation(description: "Subscriber’s delegate receives didUpdatePublisherPresence with isPresent \(expectedIsPresent)")
+        delegate.subscriberSenderDidUpdatePublisherPresenceClosure = { _, isPresent in
+            XCTAssertEqual(isPresent, expectedIsPresent)
+            delegateDidFailWithErrorCalledExpectation.fulfill()
+        }
+        
+        ablySubscriber.subscriberDelegate?.ablySubscriber(ablySubscriber, didReceivePresenceUpdate: .init(action: presenceAction, type: .publisher))
+        
+        waitForExpectations(timeout: 10)
     }
 }

--- a/Tests/SubscriberTests/Mocks/GeneratedMocks.swift
+++ b/Tests/SubscriberTests/Mocks/GeneratedMocks.swift
@@ -131,4 +131,21 @@ class SubscriberDelegateMock: SubscriberDelegate {
         subscriberSenderDidChangeAssetConnectionStatusClosure?(sender, status)
     }
 
+    //MARK: - subscriber
+
+    var subscriberSenderDidUpdatePublisherPresenceCallsCount = 0
+    var subscriberSenderDidUpdatePublisherPresenceCalled: Bool {
+        return subscriberSenderDidUpdatePublisherPresenceCallsCount > 0
+    }
+    var subscriberSenderDidUpdatePublisherPresenceReceivedArguments: (sender: Subscriber, isPresent: Bool)?
+    var subscriberSenderDidUpdatePublisherPresenceReceivedInvocations: [(sender: Subscriber, isPresent: Bool)] = []
+    var subscriberSenderDidUpdatePublisherPresenceClosure: ((Subscriber, Bool) -> Void)?
+
+    func subscriber(sender: Subscriber, didUpdatePublisherPresence isPresent: Bool) {
+        subscriberSenderDidUpdatePublisherPresenceCallsCount += 1
+        subscriberSenderDidUpdatePublisherPresenceReceivedArguments = (sender: sender, isPresent: isPresent)
+        subscriberSenderDidUpdatePublisherPresenceReceivedInvocations.append((sender: sender, isPresent: isPresent))
+        subscriberSenderDidUpdatePublisherPresenceClosure?(sender, isPresent)
+    }
+
 }


### PR DESCRIPTION
## What this does

This adds a new delegate method `SubscriberDelegate.subscriber(sender: Subscriber, didUpdatePublisherPresence isPresent: Bool)`, which informs the subscriber whether the publisher is present. I believe it's intended to provide more granular information than the existing `SubscriberDelegate.subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState)` method (see https://github.com/ably/ably-asset-tracking-common/issues/58).

It also adds a new label in the subscriber example app to display this information.

Behaviour copied from https://github.com/ably/ably-asset-tracking-android/pull/754.

Closes #368.

## Video of new label in subscriber example app


https://user-images.githubusercontent.com/53756884/193136258-3cbfded7-15ee-48e9-8696-08960b1a50f5.mov

