### PR TITLE
Remove mention of `authUrl` from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,6 @@ let connectionConfiguration = ConnectionConfiguration(clientId: clientId) { toke
 }
 ```
 
-**Alternatively, in token authentication, you can specify an _authUrl_, which will be used by Ably to authenticate.**
-
-```swift
-let connectionConfiguration = ConnectionConfiguration(authUrl: authUrl, clientId: clientId)
-```
-
 ### Ably Asset Tracking UI (Location Animator)
 
 The `Location Animator` can interpolate and animate map annotation view.


### PR DESCRIPTION
`authUrl` functionality was removed in 566c796, and doesn’t exist in Android either.