### PR TITLE
Sort accuracy values on publisher example app action sheet

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/SettingsViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/SettingsViewModel.swift
@@ -21,11 +21,11 @@ class SettingsViewModel: ObservableObject {
     
     var accuracy: String = SettingsModel.shared.constantResolution.accuracy.rawValue
     var accuracies: [String] {
-        [Accuracy.low.rawValue,
-         Accuracy.high.rawValue,
-         Accuracy.balanced.rawValue,
-         Accuracy.maximum.rawValue,
-         Accuracy.minimum.rawValue].sorted()
+        [Accuracy.low,
+         Accuracy.high,
+         Accuracy.balanced,
+         Accuracy.maximum,
+         Accuracy.minimum].sorted().map(\.rawValue)
     }
     
     func save() {


### PR DESCRIPTION
Sort by accuracy instead of alphabetically.

Closes #386.

Before:

![Simulator Screen Shot - iPhone 14 - 2022-10-10 at 13 57 03](https://user-images.githubusercontent.com/53756884/194918158-e07b7fdd-9959-4aeb-a379-1451743bd5e9.png)

After:

![Simulator Screen Shot - iPhone 14 - 2022-10-10 at 13 56 43](https://user-images.githubusercontent.com/53756884/194918177-d6fc9198-5b9d-43e5-9fda-04e44bc47b41.png)
