### PR TITLE
Remove leftover bits of SwiftLint in the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,6 @@ and then manually merge the delta contents in to the main change log (where `v1.
 ## Coding Conventions and Style Guide
 
 - Favor Protocol Oriented Programming with Dependency Injection when writing any code. We're unable to create automatic mocks in Swift, so it'll be helpful for writing unit tests.
-- SwiftLint is integrated into the project. Make sure that your code does not add any SwiftLint related warning.
 - Please remove default Xcode header comments (with author, license and creation date) as they're not necessary.
 - If you're adding or modifying any part of the public interface of SDK, please also update [QuickHelp](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/SymbolDocumentation.html#//apple_ref/doc/uid/TP40016497-CH51-SW1) documentation.
 

--- a/Examples/SubscriberExample/SubscriberExample.xcodeproj/project.pbxproj
+++ b/Examples/SubscriberExample/SubscriberExample.xcodeproj/project.pbxproj
@@ -214,7 +214,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 180F60E6258632B50014B310 /* Build configuration list for PBXNativeTarget "SubscriberExample" */;
 			buildPhases = (
-				183BE6B12588A5D40097A30B /* Run SwiftLint */,
 				180F60CE258632B40014B310 /* Sources */,
 				180F60CF258632B40014B310 /* Frameworks */,
 				180F60D0258632B40014B310 /* Resources */,
@@ -285,27 +284,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		183BE6B12588A5D40097A30B /* Run SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint lint --config \"../../.swiftlint.yml\"\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		180F60CE258632B40014B310 /* Sources */ = {

--- a/Scripts/run_linter.sh
+++ b/Scripts/run_linter.sh
@@ -1,5 +1,0 @@
-if which swiftlint >/dev/null; then
-  swiftlint lint --config .swiftlint.yml
-else
-  echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
-fi


### PR DESCRIPTION
We’ve never made proper use of it. Removing misleading leftovers until we do so.