### PR TITLE
Upload test results to test observability server

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,3 +36,10 @@ jobs:
         with:
           name: xcodebuild-logs
           path: ~/Library/Developer/Xcode/DerivedData/*/Logs
+
+      - name: Upload test results
+        if: always()
+        uses: ably/test-observability-action@v1
+        with:
+          server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
+          path: '.'

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ PublisherExample/amplifyconfiguration.json
 
 # AppCode IDE
 .idea
+
+# Test results
+/results.junit


### PR DESCRIPTION
Resolves #432.

Here's an example of a successful upload (with a deliberate test failure): https://test-observability.herokuapp.com/repos/ably/ably-asset-tracking-swift/uploads/719f4d4f-e5cd-4811-888e-8179f443873f