### PR TITLE
Deprecate ability to specify client ID when using token-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ let connectionConfiguration = ConnectionConfiguration(apiKey: ABLY_API_KEY, clie
 **To use token authentication, you can pass a closure which will be called when the Ably client needs to authenticate or reauthenticate:**
 
 ```swift
-let connectionConfiguration = ConnectionConfiguration(clientId: clientId) { tokenParams, resultHandler in
+let connectionConfiguration = ConnectionConfiguration() { tokenParams, resultHandler in
 
     // Implement a request to your servers which provides either a TokenRequest (simplest), TokenDetails, JWT or token string.
 

--- a/Sources/AblyAssetTrackingCore/Configuration/ConnectionConfiguration.swift
+++ b/Sources/AblyAssetTrackingCore/Configuration/ConnectionConfiguration.swift
@@ -49,9 +49,18 @@ public class ConnectionConfiguration {
         given token parameters.
         - clientId: Optional identifier to be assigned to this client.
      */
-    public convenience init(clientId: String? = nil, authCallback: @escaping AuthCallback) {
+    @available(*, deprecated,
+                message: "The ability to specify a client ID when using token-based authentication has been deprecated. You should use init(authCallback:) instead, which will use the client ID contained in the fetched token.",
+                renamed: "init(authCallback:)")
+    public convenience init(clientId: String, authCallback: @escaping AuthCallback) {
         self.init(apiKey: nil,
                   clientId: clientId,
+                  authCallback: authCallback)
+    }
+    
+    public convenience init(authCallback: @escaping AuthCallback) {
+        self.init(apiKey: nil,
+                  clientId: nil,
                   authCallback: authCallback)
     }
     


### PR DESCRIPTION
Closes #384.