### PR TITLE
Publisher example: Make sure we start publisher from main thread

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -96,7 +96,7 @@ class CreatePublisherViewModel: ObservableObject {
         }
     }
     
-    func createPublisher() async throws -> ObservablePublisher {
+    @MainActor func createPublisher() async throws -> ObservablePublisher {
         let connectionConfiguration = ConnectionConfiguration(apiKey: EnvironmentHelper.ABLY_API_KEY, clientId: "Asset Tracking Publisher Example")
         let resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
 


### PR DESCRIPTION
I noticed that in the publisher example app, the trackables are no longer transitioning to the online state. This appears to have been broken by a change in ac20806 where we started creating the publisher inside an `async` function and hence potentially no longer on the main thread.

This SDK does not explain the rules re from which threads it can be interacted with. I have created #445 to decide and document these rules.