### PR TITLE
Add `agents` property to `LocationHistoryData`

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0CFCA307289131AB00A1A6B5 /* UserDefaults+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFCA305289131AB00A1A6B5 /* UserDefaults+Codable.swift */; };
 		0CFCA308289131AB00A1A6B5 /* CloseKeyboardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFCA306289131AB00A1A6B5 /* CloseKeyboardHelper.swift */; };
 		0CFCA30A2891325700A1A6B5 /* AddTrackableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFCA3092891325700A1A6B5 /* AddTrackableView.swift */; };
+		21036A832911A5B900704723 /* LocationHistoryUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21036A822911A5B900704723 /* LocationHistoryUploader.swift */; };
 		2108B75329097498002778CA /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 2108B75229097498002778CA /* AWSCognitoAuthPlugin */; };
 		2108B75529097498002778CA /* AWSS3StoragePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 2108B75429097498002778CA /* AWSS3StoragePlugin */; };
 		2108B75729097498002778CA /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 2108B75629097498002778CA /* Amplify */; };
@@ -73,6 +74,7 @@
 		0CFCA305289131AB00A1A6B5 /* UserDefaults+Codable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Codable.swift"; sourceTree = "<group>"; };
 		0CFCA306289131AB00A1A6B5 /* CloseKeyboardHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloseKeyboardHelper.swift; sourceTree = "<group>"; };
 		0CFCA3092891325700A1A6B5 /* AddTrackableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddTrackableView.swift; sourceTree = "<group>"; };
+		21036A822911A5B900704723 /* LocationHistoryUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHistoryUploader.swift; sourceTree = "<group>"; };
 		2108B758290974B8002778CA /* S3Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = S3Helper.swift; sourceTree = "<group>"; };
 		2108B75A290975BC002778CA /* Optional Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Optional Resources"; sourceTree = "<group>"; };
 		2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+ErrorInformation.swift"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				21AE71A5290B27BE00427F04 /* UploadsManager.swift */,
 				21BB909329119015005C78AF /* UploadRequest.swift */,
 				21BB909629119067005C78AF /* Upload.swift */,
+				21036A822911A5B900704723 /* LocationHistoryUploader.swift */,
 			);
 			path = Uploads;
 			sourceTree = "<group>";
@@ -422,6 +425,7 @@
 				21BB909729119067005C78AF /* Upload.swift in Sources */,
 				D5DBAF7027746105008B8DED /* StackedText.swift in Sources */,
 				0CFCA3042891315700A1A6B5 /* SettingsModel.swift in Sources */,
+				21036A832911A5B900704723 /* LocationHistoryUploader.swift in Sources */,
 				21F1993228FF40E6004FE626 /* PublisherDetailsView.swift in Sources */,
 				0CC893BA28FEBBB3004F7B9A /* VehicleProfile+description.swift in Sources */,
 				2139286728F783A40073DE99 /* Alert+ErrorInformation.swift in Sources */,

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
@@ -28,11 +28,13 @@
 		2139286728F783A40073DE99 /* Alert+ErrorInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */; };
 		2144B8212908276F00958144 /* SelectDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8202908276F00958144 /* SelectDestinationView.swift */; };
 		2144B8252908278B00958144 /* DestinationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8242908278B00958144 /* DestinationMapView.swift */; };
+		21AE71A6290B27BE00427F04 /* UploadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE71A5290B27BE00427F04 /* UploadsManager.swift */; };
 		21B6446B28FDC68C00156F94 /* AddTrackableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6446A28FDC68C00156F94 /* AddTrackableViewModel.swift */; };
 		21B6B2A829097EAF001E2FB7 /* LocationSourceOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6B2A729097EAF001E2FB7 /* LocationSourceOption.swift */; };
 		21B6B2AA29097FEC001E2FB7 /* S3FilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6B2A929097FEB001E2FB7 /* S3FilesView.swift */; };
 		21B6B2AC2909800B001E2FB7 /* S3FilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6B2AB2909800B001E2FB7 /* S3FilesViewModel.swift */; };
 		21BB909429119015005C78AF /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB909329119015005C78AF /* UploadRequest.swift */; };
+		21BB909729119067005C78AF /* Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB909629119067005C78AF /* Upload.swift */; };
 		21CF8DFE28F8566D005E7CE6 /* ObservablePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8DFD28F8566D005E7CE6 /* ObservablePublisher.swift */; };
 		21CF8E0328F875DF005E7CE6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8E0228F875DF005E7CE6 /* SettingsView.swift */; };
 		21CF8E0528F875E8005E7CE6 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8E0428F875E8005E7CE6 /* SettingsViewModel.swift */; };
@@ -74,11 +76,13 @@
 		2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+ErrorInformation.swift"; sourceTree = "<group>"; };
 		2144B8202908276F00958144 /* SelectDestinationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectDestinationView.swift; sourceTree = "<group>"; };
 		2144B8242908278B00958144 /* DestinationMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationMapView.swift; sourceTree = "<group>"; };
+		21AE71A5290B27BE00427F04 /* UploadsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsManager.swift; sourceTree = "<group>"; };
 		21B6446A28FDC68C00156F94 /* AddTrackableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackableViewModel.swift; sourceTree = "<group>"; };
 		21B6B2A729097EAF001E2FB7 /* LocationSourceOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationSourceOption.swift; sourceTree = "<group>"; };
 		21B6B2A929097FEB001E2FB7 /* S3FilesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = S3FilesView.swift; sourceTree = "<group>"; };
 		21B6B2AB2909800B001E2FB7 /* S3FilesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = S3FilesViewModel.swift; sourceTree = "<group>"; };
 		21BB909329119015005C78AF /* UploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadRequest.swift; sourceTree = "<group>"; };
+		21BB909629119067005C78AF /* Upload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upload.swift; sourceTree = "<group>"; };
 		21CF8DFD28F8566D005E7CE6 /* ObservablePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservablePublisher.swift; sourceTree = "<group>"; };
 		21CF8E0228F875DF005E7CE6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		21CF8E0428F875E8005E7CE6 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -143,7 +147,9 @@
 		21BB909529119053005C78AF /* Uploads */ = {
 			isa = PBXGroup;
 			children = (
+				21AE71A5290B27BE00427F04 /* UploadsManager.swift */,
 				21BB909329119015005C78AF /* UploadRequest.swift */,
+				21BB909629119067005C78AF /* Upload.swift */,
 			);
 			path = Uploads;
 			sourceTree = "<group>";
@@ -399,6 +405,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21BB909729119067005C78AF /* Upload.swift in Sources */,
 				D5DBAF7027746105008B8DED /* StackedText.swift in Sources */,
 				0CFCA3042891315700A1A6B5 /* SettingsModel.swift in Sources */,
 				21F1993228FF40E6004FE626 /* PublisherDetailsView.swift in Sources */,
@@ -417,6 +424,7 @@
 				0CFCA2FD289130E700A1A6B5 /* ListItem.swift in Sources */,
 				21E6EBF828F97B200057AC7C /* Map.swift in Sources */,
 				0CFCA30A2891325700A1A6B5 /* AddTrackableView.swift in Sources */,
+				21AE71A6290B27BE00427F04 /* UploadsManager.swift in Sources */,
 				21CF8DFE28F8566D005E7CE6 /* ObservablePublisher.swift in Sources */,
 				0CFCA307289131AB00A1A6B5 /* UserDefaults+Codable.swift in Sources */,
 				2144B8252908278B00958144 /* DestinationMapView.swift in Sources */,

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2139286728F783A40073DE99 /* Alert+ErrorInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */; };
 		2144B8212908276F00958144 /* SelectDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8202908276F00958144 /* SelectDestinationView.swift */; };
 		2144B8252908278B00958144 /* DestinationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8242908278B00958144 /* DestinationMapView.swift */; };
+		21AE71A4290B1D6500427F04 /* UploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE71A3290B1D6500427F04 /* UploadsView.swift */; };
 		21AE71A6290B27BE00427F04 /* UploadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE71A5290B27BE00427F04 /* UploadsManager.swift */; };
 		21B6446B28FDC68C00156F94 /* AddTrackableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6446A28FDC68C00156F94 /* AddTrackableViewModel.swift */; };
 		21B6B2A829097EAF001E2FB7 /* LocationSourceOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6B2A729097EAF001E2FB7 /* LocationSourceOption.swift */; };
@@ -35,6 +36,7 @@
 		21B6B2AC2909800B001E2FB7 /* S3FilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6B2AB2909800B001E2FB7 /* S3FilesViewModel.swift */; };
 		21BB909429119015005C78AF /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB909329119015005C78AF /* UploadRequest.swift */; };
 		21BB909729119067005C78AF /* Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB909629119067005C78AF /* Upload.swift */; };
+		21BB909A291190E7005C78AF /* UploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB9099291190E7005C78AF /* UploadView.swift */; };
 		21CF8DFE28F8566D005E7CE6 /* ObservablePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8DFD28F8566D005E7CE6 /* ObservablePublisher.swift */; };
 		21CF8E0328F875DF005E7CE6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8E0228F875DF005E7CE6 /* SettingsView.swift */; };
 		21CF8E0528F875E8005E7CE6 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF8E0428F875E8005E7CE6 /* SettingsViewModel.swift */; };
@@ -76,6 +78,7 @@
 		2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+ErrorInformation.swift"; sourceTree = "<group>"; };
 		2144B8202908276F00958144 /* SelectDestinationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectDestinationView.swift; sourceTree = "<group>"; };
 		2144B8242908278B00958144 /* DestinationMapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationMapView.swift; sourceTree = "<group>"; };
+		21AE71A3290B1D6500427F04 /* UploadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsView.swift; sourceTree = "<group>"; };
 		21AE71A5290B27BE00427F04 /* UploadsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsManager.swift; sourceTree = "<group>"; };
 		21B6446A28FDC68C00156F94 /* AddTrackableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackableViewModel.swift; sourceTree = "<group>"; };
 		21B6B2A729097EAF001E2FB7 /* LocationSourceOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationSourceOption.swift; sourceTree = "<group>"; };
@@ -83,6 +86,7 @@
 		21B6B2AB2909800B001E2FB7 /* S3FilesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = S3FilesViewModel.swift; sourceTree = "<group>"; };
 		21BB909329119015005C78AF /* UploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadRequest.swift; sourceTree = "<group>"; };
 		21BB909629119067005C78AF /* Upload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upload.swift; sourceTree = "<group>"; };
+		21BB9099291190E7005C78AF /* UploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadView.swift; sourceTree = "<group>"; };
 		21CF8DFD28F8566D005E7CE6 /* ObservablePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservablePublisher.swift; sourceTree = "<group>"; };
 		21CF8E0228F875DF005E7CE6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		21CF8E0428F875E8005E7CE6 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
@@ -150,6 +154,15 @@
 				21AE71A5290B27BE00427F04 /* UploadsManager.swift */,
 				21BB909329119015005C78AF /* UploadRequest.swift */,
 				21BB909629119067005C78AF /* Upload.swift */,
+			);
+			path = Uploads;
+			sourceTree = "<group>";
+		};
+		21BB9098291190C8005C78AF /* Uploads */ = {
+			isa = PBXGroup;
+			children = (
+				21AE71A3290B1D6500427F04 /* UploadsView.swift */,
+				21BB9099291190E7005C78AF /* UploadView.swift */,
 			);
 			path = Uploads;
 			sourceTree = "<group>";
@@ -263,6 +276,7 @@
 		D544FB202771D8290015925C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				21BB9098291190C8005C78AF /* Uploads */,
 				21B6B2A929097FEB001E2FB7 /* S3FilesView.swift */,
 				2144B8202908276F00958144 /* SelectDestinationView.swift */,
 				21F1993128FF40E6004FE626 /* PublisherDetailsView.swift */,
@@ -412,6 +426,7 @@
 				0CC893BA28FEBBB3004F7B9A /* VehicleProfile+description.swift in Sources */,
 				2139286728F783A40073DE99 /* Alert+ErrorInformation.swift in Sources */,
 				D544FAF62771B3560015925C /* PublisherExampleSwiftUIApp.swift in Sources */,
+				21AE71A4290B1D6500427F04 /* UploadsView.swift in Sources */,
 				D5DBAF7527748116008B8DED /* RoutingProfile.swift in Sources */,
 				2144B8212908276F00958144 /* SelectDestinationView.swift in Sources */,
 				21B6B2AA29097FEC001E2FB7 /* S3FilesView.swift in Sources */,
@@ -427,6 +442,7 @@
 				21AE71A6290B27BE00427F04 /* UploadsManager.swift in Sources */,
 				21CF8DFE28F8566D005E7CE6 /* ObservablePublisher.swift in Sources */,
 				0CFCA307289131AB00A1A6B5 /* UserDefaults+Codable.swift in Sources */,
+				21BB909A291190E7005C78AF /* UploadView.swift in Sources */,
 				2144B8252908278B00958144 /* DestinationMapView.swift in Sources */,
 				21F1992F28FF40B2004FE626 /* DummyPublisher.swift in Sources */,
 				0CFCA2FF289130E700A1A6B5 /* TitleValueListItem.swift in Sources */,

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
@@ -4,6 +4,7 @@ import AblyAssetTrackingPublisher
 class ObservablePublisher: ObservableObject {
     private let publisher: AblyAssetTrackingPublisher.Publisher
     let configInfo: PublisherConfigInfo
+    let locationHistoryDataHandler: LocationHistoryDataHandlerProtocol?
     
     struct PublisherConfigInfo {
         var areRawLocationsEnabled: Bool
@@ -20,10 +21,11 @@ class ObservablePublisher: ObservableObject {
     @Published private(set) var lastError: ErrorInformation?
     
     // After initialising an ObservablePublisher instance, you need to manually set the publisher’s delegate to the created instance.
-    init(publisher: AblyAssetTrackingPublisher.Publisher, configInfo: PublisherConfigInfo) {
+    init(publisher: AblyAssetTrackingPublisher.Publisher, configInfo: PublisherConfigInfo, locationHistoryDataHandler: LocationHistoryDataHandlerProtocol? = nil) {
         self.publisher = publisher
         self.configInfo = configInfo
         self.routingProfile = publisher.routingProfile
+        self.locationHistoryDataHandler = locationHistoryDataHandler
     }
     
     func stop(completion: @escaping ResultHandler<Void>) {
@@ -79,5 +81,9 @@ extension ObservablePublisher: PublisherDelegate {
     
     func publisher(sender: AblyAssetTrackingPublisher.Publisher, didChangeTrackables trackables: Set<AblyAssetTrackingCore.Trackable>) {
         updateTrackables(latestReceived: trackables)
+    }
+    
+    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData) {
+        locationHistoryDataHandler?.handleLocationHistoryData(locationHistoryData)
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/LocationHistoryUploader.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/LocationHistoryUploader.swift
@@ -1,0 +1,20 @@
+import AblyAssetTrackingPublisher
+import Foundation
+
+protocol LocationHistoryDataHandlerProtocol {
+    func handleLocationHistoryData(_ locationHistoryData: LocationHistoryData)
+}
+
+class LocationHistoryDataUploader: LocationHistoryDataHandlerProtocol {
+    private let uploadsManager: UploadsManager
+    
+    init(uploadsManager: UploadsManager) {
+        self.uploadsManager = uploadsManager
+    }
+    
+    func handleLocationHistoryData(_ locationHistoryData: LocationHistoryData) {
+        Task { @MainActor in
+            uploadsManager.upload(locationHistoryData: locationHistoryData)
+        }
+    }
+}

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/Upload.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/Upload.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct Upload: Identifiable {
+    var id = UUID()
+    var request: UploadRequest
+    
+    enum Status: CustomStringConvertible {
+        case uploading
+        case uploaded
+        case failed(Error)
+        
+        var description: String {
+            switch self {
+            case .uploading: return "Uploading"
+            case .uploaded: return "Uploaded"
+            case .failed(let error): return "Failed: \(error.localizedDescription)"
+            }
+        }
+    }
+    
+    var status: Status
+}

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Combine
+import AblyAssetTrackingPublisher
+import Logging
+
+class UploadsManager: ObservableObject {
+    @MainActor @Published private(set) var uploads: [Upload] = []
+    private let s3Helper: S3Helper?
+    private let logger: Logger
+    
+    init(s3Helper: S3Helper?, logger: Logger) {
+        self.s3Helper = s3Helper
+        self.logger = logger
+    }
+    
+    @MainActor func upload(locationHistoryData: LocationHistoryData) {
+        guard let s3Helper = s3Helper else {
+            logger.info("Skipping upload of location history data since S3 is not configured")
+            return
+        }
+        
+        let request = UploadRequest(data: locationHistoryData, generatedAt: Date())
+        
+        let upload = Upload(request: request, status: .uploading)
+        logger.info("Starting upload \(upload.id) of location history data")
+        uploads.insert(upload, at: 0)
+        
+        Task {
+            do {
+                try await s3Helper.upload(request)
+            } catch {
+                logger.error("Upload \(upload.id) of location history data failed: \(error.localizedDescription)")
+                updateStatus(forUploadWithId: upload.id, status: .failed(error))
+            }
+            
+            logger.info("Upload \(upload.id) of location history data succeeded.")
+            updateStatus(forUploadWithId: upload.id, status: .uploaded)
+        }
+    }
+    
+    @MainActor private func updateStatus(forUploadWithId id: UUID, status: Upload.Status) {
+        guard let index = uploads.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        
+        uploads[index].status = status
+    }
+}

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
@@ -28,7 +28,7 @@ struct PublisherExampleSwiftUIApp: App {
                 */
                 .navigationViewStyle(.stack)
                 NavigationView {
-                    SettingsView()
+                    SettingsView(uploads: uploadsManager.uploads)
                 }
                 // Same comment as above
                 .navigationViewStyle(.stack)

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
@@ -3,18 +3,33 @@ import Logging
 
 @main
 struct PublisherExampleSwiftUIApp: App {
-    @State private var logger: Logger = {
-        var logger = Logger(label: "com.ably.PublisherExampleSwiftUI")
-        logger.logLevel = .info
-        return logger
-    }()
-    @State private var s3Helper = try? S3Helper()
+    @State private var logger: Logger
+    @State private var s3Helper: S3Helper?
+    @StateObject private var uploadsManager: UploadsManager
+    @State private var locationHistoryDataHandler: LocationHistoryDataHandlerProtocol
+    
+    init() {
+        let logger: Logger = {
+            var logger = Logger(label: "com.ably.PublisherExampleSwiftUI")
+            logger.logLevel = .info
+            return logger
+        }()
+        self._logger = State(wrappedValue: logger)
+        
+        let s3Helper = try? S3Helper()
+        self._s3Helper = State(wrappedValue: s3Helper)
+        
+        let uploadsManager = UploadsManager(s3Helper: s3Helper, logger: logger)
+        _uploadsManager = StateObject(wrappedValue: uploadsManager)
+        
+        self._locationHistoryDataHandler = State(wrappedValue: LocationHistoryDataUploader(uploadsManager: uploadsManager))
+    }
     
     var body: some Scene {
         WindowGroup {
             TabView {
                 NavigationView {
-                    CreatePublisherView(logger: logger, s3Helper: s3Helper)
+                    CreatePublisherView(logger: logger, s3Helper: s3Helper, locationHistoryDataHandler: locationHistoryDataHandler)
                 }
                 .tabItem {
                     Label("Publisher", systemImage: "car")

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
@@ -20,9 +20,9 @@ struct CreatePublisherView: View {
         
     private var s3Helper: S3Helper?
 
-    init(logger: Logger, s3Helper: S3Helper? = nil) {
+    init(logger: Logger, s3Helper: S3Helper? = nil, locationHistoryDataHandler: LocationHistoryDataHandlerProtocol? = nil) {
         self.s3Helper = s3Helper
-        _viewModel = StateObject(wrappedValue: CreatePublisherViewModel(logger: logger, s3Helper: s3Helper))
+        _viewModel = StateObject(wrappedValue: CreatePublisherViewModel(logger: logger, s3Helper: s3Helper, locationHistoryDataHandler: locationHistoryDataHandler))
     }
     
     var body: some View {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
     @State var showDefaultAccuracies = false
+    var uploads: [Upload]
     
     var body: some View {
         List {
@@ -34,13 +35,19 @@ struct SettingsView: View {
                 Toggle(isOn: $viewModel.useMapboxMap) {
                     Text("Use Mapbox map")
                 }
+                
+                NavigationLink("Uploads") {
+                    UploadsView(uploads: uploads)
+                }
             } header: {
                 Text("Other settings")
             }
         }
         .listStyle(.grouped)
         .navigationBarTitle("Settings")
-        .resignKeyboardOnTapGesture()
+        // Had to remove this because it stops the "Create publisher" button from doing anything.
+        // See https://github.com/ably/ably-asset-tracking-swift/issues/421
+        // .resignKeyboardOnTapGesture()
         .onDisappear {
             viewModel.save()
         }
@@ -49,6 +56,7 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
+        let upload = Upload(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading)
+        SettingsView(uploads: [upload])
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct UploadView: View {
+    var upload: Upload
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("📄 \(upload.request.filename)")
+                .fontWeight(.bold)
+            HStack {
+                Text(String(describing: upload.status))
+            }
+        }
+    }
+}
+
+struct UploadView_Previews: PreviewProvider {
+    static var previews: some View {
+        UploadView(upload: .init(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading))
+    }
+}

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct UploadsView: View {
+    var uploads: [Upload]
+    
+    var body: some View {
+        List(uploads.sorted(by: { $0.request.generatedAt > $1.request.generatedAt })) { upload in
+            UploadView(upload: upload)
+        }
+        .navigationTitle("Uploads")
+    }
+}
+
+struct UploadsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let uploads = (1...10).map { _ in
+            Upload(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading)
+        }
+        
+        NavigationView {
+            UploadsView(uploads: uploads)
+        }
+    }
+}

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -9,14 +9,16 @@ class CreatePublisherViewModel: ObservableObject {
     
     private let s3Helper: S3Helper?
     private let logger: Logger
+    private let locationHistoryDataHandler: LocationHistoryDataHandlerProtocol?
     
     private var isS3Available: Bool {
         s3Helper != nil
     }
     
-    init(logger: Logger, s3Helper: S3Helper?) {
+    init(logger: Logger, s3Helper: S3Helper?, locationHistoryDataHandler: LocationHistoryDataHandlerProtocol?) {
         self.s3Helper = s3Helper
         self.logger = logger
+        self.locationHistoryDataHandler = locationHistoryDataHandler
     }
     
     @Published var areRawLocationsEnabled: Bool = SettingsModel.shared.areRawLocationsEnabled {
@@ -134,7 +136,7 @@ class CreatePublisherViewModel: ObservableObject {
         
         let configInfo = ObservablePublisher.PublisherConfigInfo(areRawLocationsEnabled: areRawLocationsEnabled, constantResolution: constantResolution)
         
-        let observablePublisher = ObservablePublisher(publisher: publisher, configInfo: configInfo)
+        let observablePublisher = ObservablePublisher(publisher: publisher, configInfo: configInfo, locationHistoryDataHandler: locationHistoryDataHandler)
         publisher.delegate = observablePublisher
         
         return observablePublisher

--- a/Sources/AblyAssetTrackingInternal/Configuration/Agents.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/Agents.swift
@@ -1,0 +1,30 @@
+import AblyAssetTrackingCore
+import Ably
+
+public struct Agents {
+    private struct Agent {
+        public var name: String
+        public var version: String?
+        
+        init(name: String, version: String?) {
+            self.name = name
+            self.version = version
+        }
+    }
+    
+    private var agents: [Agent]
+    
+    public static let libraryAgents: Agents = .init(agents: [
+        .init(name: "ably-asset-tracking-swift", version: Version.libraryVersion)
+    ])
+}
+
+extension Agents {
+    public var ablyCocoaAgentsDictionary: [String: String] {
+        return agents.reduce([:]) { dict, agent in
+            var newDict = dict
+            newDict[agent.name] = agent.version ?? ARTClientInformationAgentNotVersioned
+            return newDict
+        }
+    }
+}

--- a/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
@@ -21,7 +21,7 @@ extension ConnectionConfiguration {
         clientOptions.logLevel = .verbose
         clientOptions.logHandler = logHandler
         
-        clientOptions.agents = ["ably-asset-tracking-swift": Version.libraryVersion]
+        clientOptions.agents = Agents.libraryAgents.ablyCocoaAgentsDictionary
         
         if let environment = environment {
             clientOptions.environment = environment

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
@@ -158,6 +158,7 @@ extension DefaultPublisher {
         case error(ErrorEvent)
         case enhancedLocationChanged(EnhancedLocationChangedEvent)
         case trackableConnectionStateChanged(TrackableConnectionStateChangedEvent)
+        case finishedRecordingLocationHistoryData(FinishedRecordingLocationHistoryDataEvent)
         
         struct ErrorEvent {
             let error: ErrorInformation
@@ -170,6 +171,10 @@ extension DefaultPublisher {
         struct TrackableConnectionStateChangedEvent {
             let trackable: Trackable
             let connectionState: ConnectionState
+        }
+        
+        struct FinishedRecordingLocationHistoryDataEvent {
+            let locationHistoryData: LocationHistoryData
         }
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -47,4 +47,16 @@ public protocol PublisherDelegate: AnyObject {
         - trackables: a set of trackables that are currently present on the `sender`'s instance
     */
     func publisher(sender: Publisher, didChangeTrackables trackables: Set<Trackable>)
+    
+    /**
+     Called when the publisher has finished recording location history data, to expose the data that it recorded. The publisher will call this method after it receives the ``Publisher/stop(completion:)`` method call and before that method’s completion handler is called. It will only do so if at least one trackable was added to the publisher during its lifetime.
+     */
+    func publisher(sender: Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData)
+}
+
+public extension PublisherDelegate {
+    /**
+     Default implementation to make this method `optional`
+     */
+    func publisher(sender: Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData) {}
 }

--- a/Sources/AblyAssetTrackingPublisher/Services/LocationService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/LocationService.swift
@@ -11,5 +11,7 @@ protocol LocationService: AnyObject {
     var delegate: LocationServiceDelegate? { get set }
     func startUpdatingLocation()
     func stopUpdatingLocation()
+    func startRecordingLocation()
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>)
     func changeLocationEngineResolution(resolution: Resolution)
 }

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -895,6 +895,7 @@ class DefaultPublisherTests: XCTestCase {
     func testStopEventCauseImpossibilityOfEnqueueOtherEvents() {
         ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         ablyPublisher.closeResultCompletionHandler = { completion in completion?(.success)}
+        locationService.stopRecordingLocationCallback = { completion in completion(.success(nil)) }
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,

--- a/Tests/PublisherTests/LocationHistoryDataTests.swift
+++ b/Tests/PublisherTests/LocationHistoryDataTests.swift
@@ -10,6 +10,17 @@ final class LocationHistoryDataTests: XCTestCase {
         XCTAssertEqual(locationHistoryData.version, 1)
     }
     
+    func testAgents() throws {
+        let locationHistoryData = LocationHistoryData(events: [])
+        
+        let agents = try XCTUnwrap(locationHistoryData.agents)
+        
+        // e.g. "ably-cocoa/1.2.16 ably-asset-tracking-swift/1.0.0-rc.1 iOS/16.1.0"
+        XCTAssertTrue(agents.contains("ably-cocoa/"))
+        XCTAssertTrue(agents.contains("ably-asset-tracking-swift/"))
+        XCTAssertTrue(agents.contains("iOS/"))
+    }
+    
     // MARK: Decodable
     
     func testDecodable_decodesTestResource_version1_validAndroid() throws {
@@ -25,7 +36,9 @@ final class LocationHistoryDataTests: XCTestCase {
         let jsonData = try Data(contentsOf: jsonFileUrl)
         
         let decoder = JSONDecoder()
-        let _ = try decoder.decode(LocationHistoryData.self, from: jsonData)
+        let locationHistoryData = try decoder.decode(LocationHistoryData.self, from: jsonData)
+        
+        XCTAssertEqual(locationHistoryData.agents, "ably-cocoa/1.2.16 ably-asset-tracking-swift/1.0.0-rc.1 iOS/16.1.0")
     }
     
     func testDecodable_withMajorVersionGreaterThan2_throwsUnsupportedVersionError() throws {
@@ -51,6 +64,18 @@ final class LocationHistoryDataTests: XCTestCase {
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData)
         let dictionary = try XCTUnwrap(jsonObject as? [String: Any])
         
-        XCTAssertEqual(dictionary["version"] as? String, "2.0.0-wip")
+        XCTAssertEqual(dictionary["version"] as? String, "2.0.0")
+    }
+    
+    func testEncodable_encodesAgents() throws {
+        let locationHistoryData = LocationHistoryData(events: [])
+        
+        let encoder = JSONEncoder()
+        let jsonData = try encoder.encode(locationHistoryData)
+        
+        let jsonObject = try JSONSerialization.jsonObject(with: jsonData)
+        let dictionary = try XCTUnwrap(jsonObject as? [String: Any])
+        
+        XCTAssertEqual(dictionary["agents"] as? String, locationHistoryData.agents)
     }
 }

--- a/Tests/PublisherTests/Mocks/MockLocationService.swift
+++ b/Tests/PublisherTests/Mocks/MockLocationService.swift
@@ -24,4 +24,18 @@ class MockLocationService: LocationService {
     func stopUpdatingLocation() {
         stopUpdatingLocationCalled = true
     }
+    
+    var startRecordingLocationCalled = false
+    func startRecordingLocation() {
+        startRecordingLocationCalled = true
+    }
+    
+    var stopRecordingLocationCalled = false
+    var stopRecordingLocationParamCompletion: ResultHandler<LocationHistoryData?>?
+    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationHistoryData?>) -> Void)?
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>) {
+        stopRecordingLocationCalled = true
+        stopRecordingLocationParamCompletion = completion
+        stopRecordingLocationCallback?(completion)
+    }
 }

--- a/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
+++ b/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
@@ -60,4 +60,15 @@ class MockPublisherDelegate: PublisherDelegate {
         publisherDidChangeTrackablesParamTrackables = trackables
         publisherDidChangeTrackablesCallback?()
     }
+    
+    var publisherDidFinishRecordingLocationHistoryDataCalled: Bool = false
+    var publisherDidFinishRecordingLocationHistoryDataParamSender: Publisher?
+    var publisherDidFinishRecordingLocationHistoryDataParamLocationHistoryData: LocationHistoryData?
+    var publisherDidFinishRecordingLocationHistoryDataCallback: (() -> Void)?
+    func publisher(sender: Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData) {
+        publisherDidFinishRecordingLocationHistoryDataCalled = true
+        publisherDidFinishRecordingLocationHistoryDataParamSender = sender
+        publisherDidFinishRecordingLocationHistoryDataParamLocationHistoryData = locationHistoryData
+        publisherDidFinishRecordingLocationHistoryDataCallback?()
+    }
 }

--- a/Tests/SystemTests/Mocks/MockLocationService.swift
+++ b/Tests/SystemTests/Mocks/MockLocationService.swift
@@ -24,4 +24,18 @@ class MockLocationService: LocationService {
     func stopUpdatingLocation() {
         stopUpdatingLocationCalled = true
     }
+    
+    var startRecordingLocationCalled = false
+    func startRecordingLocation() {
+        startRecordingLocationCalled = true
+    }
+    
+    var stopRecordingLocationCalled = false
+    var stopRecordingLocationParamCompletion: ResultHandler<LocationHistoryData?>?
+    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationHistoryData?>) -> Void)?
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>) {
+        stopRecordingLocationCalled = true
+        stopRecordingLocationParamCompletion = completion
+        stopRecordingLocationCallback?(completion)
+    }
 }


### PR DESCRIPTION
This implements the property that’s in the `version-2.0.0` schema in the `external/common` repo.

**Note this is based on #467, so please review that one first.**

Closes #451.