### PR TITLE
Partial fix for routing profile change issue

### DIFF
--- a/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
@@ -3,7 +3,7 @@ import MapboxDirections
 import AblyAssetTrackingCore
 
 protocol RouteProvider {
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
+    func getRoute(to destination: CLLocationCoordinate2D?, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
     func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
 }
 
@@ -23,12 +23,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
 
     func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
         self.routingProfile = routingProfile
-        guard let destination = destination else {
-            let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Cannot change routing profile when destination is not available"))
-            completion(.failure(errorInformation))
-            return
-        }
-        
+    
         if isCalculating(resultHandler: completion){
             return
         }
@@ -38,7 +33,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
                  completion: completion)
     }
 
-    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    func getRoute(to destination: CLLocationCoordinate2D?, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
 
         if isCalculating(resultHandler: completion) {
             return

--- a/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
@@ -3,7 +3,7 @@ import MapboxDirections
 import AblyAssetTrackingCore
 
 protocol RouteProvider {
-    func getRoute(to destination: CLLocationCoordinate2D?, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
     func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
 }
 
@@ -23,7 +23,12 @@ class DefaultRouteProvider: NSObject, RouteProvider {
 
     func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
         self.routingProfile = routingProfile
-    
+        guard let destination = destination else {
+            let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Cannot change routing profile when destination is not available"))
+            completion(.failure(errorInformation))
+            return
+        }
+        
         if isCalculating(resultHandler: completion){
             return
         }
@@ -33,7 +38,7 @@ class DefaultRouteProvider: NSObject, RouteProvider {
                  completion: completion)
     }
 
-    func getRoute(to destination: CLLocationCoordinate2D?, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
+    func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
 
         if isCalculating(resultHandler: completion) {
             return

--- a/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
@@ -23,8 +23,13 @@ class DefaultRouteProvider: NSObject, RouteProvider {
 
     func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
         self.routingProfile = routingProfile
-        guard let destination = self.destination,
-              !isCalculating(resultHandler: completion) else {
+        guard let destination = destination else {
+            let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Cannot change routing profile when destination is not available"))
+            completion(.failure(errorInformation))
+            return
+        }
+        
+        if isCalculating(resultHandler: completion){
             return
         }
 


### PR DESCRIPTION
This is a partial fix for  https://github.com/ably/ably-asset-tracking-swift/issues/420

The problem was that, the code paths wouldn't invoke result handler in all situations. For example when destination was nil - as in this case, the function would just return without bothering with result handler.
Here I made a change that would make sure that result handler is invoked when destination is nil with a failing response when change profile action is performed.

But In Android [destination is optional.](https://github.com/ably/ably-asset-tracking-android/blob/c82d8d3cdaf681396940387d6a19928a96eb68a5/publishing-sdk/src/main/java/com/ably/tracking/publisher/workerqueue/workers/ChangeRoutingProfileWorker.kt)
This solves only the issue of us not providing a result handler when destination is nil. But the important bug is that Mapbox does not provide a way to pass an optional destination 

See https://github.com/ably/ably-asset-tracking-swift/issues/420#issuecomment-1311567241