### PR TITLE
Fix bug where, after removing a trackable, can’t add another with same ID

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
@@ -64,6 +64,10 @@ struct AblyCocoaSDKRealtimeChannel: AblySDKRealtimeChannel {
     func attach(_ callback: ARTCallback?) {
         channel.attach(callback)
     }
+    
+    var state: ARTRealtimeChannelState {
+        return channel.state
+    }
 }
 
 struct AblyCocoaSDKRealtimePresence: AblySDKRealtimePresence {

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -29,6 +29,7 @@ public protocol AblySDKRealtimeChannel {
     @discardableResult func on(_ callback: @escaping (ARTChannelStateChange) -> ()) -> AblySDKEventListener
     func publish(_ messages: [ARTMessage], callback: ARTCallback?)
     func attach(_ callback: ARTCallback?)
+    var state: ARTRealtimeChannelState { get }
 }
 
 //sourcery: AutoMockable

--- a/Tests/InternalTests/Mocks/GeneratedMocks.swift
+++ b/Tests/InternalTests/Mocks/GeneratedMocks.swift
@@ -115,6 +115,11 @@ class AblySDKRealtimeChannelMock: AblySDKRealtimeChannel {
         set(value) { underlyingPresence = value }
     }
     var underlyingPresence: AblySDKRealtimePresence!
+    var state: ARTRealtimeChannelState {
+        get { return underlyingState }
+        set(value) { underlyingState = value }
+    }
+    var underlyingState: ARTRealtimeChannelState!
 
     //MARK: - subscribe
 

--- a/Tests/SystemTests/PublisherSystemTests.swift
+++ b/Tests/SystemTests/PublisherSystemTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import AblyAssetTrackingPublisher
+
+final class PublisherSystemTests: XCTestCase {
+
+    func test_addTrackable_thenRemoveIt_thenAddAnotherTrackableWithSameId() throws {
+        let connectionConfiguration = ConnectionConfiguration(apiKey: Secrets.ablyApiKey, clientId: UUID().uuidString)
+        let resolution = Resolution(accuracy: .balanced, desiredInterval: 5000, minimumDisplacement: 100)
+        
+        let publisher = try PublisherFactory.publishers()
+            .connection(connectionConfiguration)
+            .mapboxConfiguration(MapboxConfiguration(mapboxKey: Secrets.mapboxAccessToken))
+            .resolutionPolicyFactory(DefaultResolutionPolicyFactory(defaultResolution: resolution))
+            .start()
+        
+        let trackable = Trackable(id: UUID().uuidString)
+        
+        let firstAddExpectation = expectation(description: "First add trackable call succeeds")
+        publisher.add(trackable: trackable) { result in
+            switch result {
+            case .success:
+                firstAddExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("First add trackable call failed: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        let removeExpectation = expectation(description: "Remove trackable call succeeds")
+        publisher.remove(trackable: trackable) { result in
+            switch result {
+            case .success:
+                removeExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Remove trackable call failed: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        let secondAddExpectation = expectation(description: "Second add trackable call succeeds")
+        publisher.add(trackable: trackable) { result in
+            switch result {
+            case .success:
+                secondAddExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("Second add trackable call failed: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+}


### PR DESCRIPTION
This occurs because the second time around, the channel will be in a `DETACHED` state, and trying to enter presence on that channel will give the error `unable to enter presence channel (incompatible channel state: Detached)`.

So, we follow [Android’s approach](https://github.com/ably/ably-asset-tracking-android/blob/d61ca7f3a1dc2f8c3ed5eb5def21ee9a3e0229b8/common/src/main/java/com/ably/tracking/common/Ably.kt#L363-L365), and check the channel’s state and attach if necessary before we try to enter presence.

Closes #431.