### PR TITLE
Add tests for `LocationHistoryData`

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Select Specific Xcode Version
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Select Specific Xcode Version
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Select Specific Xcode Version
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/common"]
+	path = external/common
+	url = git@github.com:ably/ably-asset-tracking-common.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ Configuration of download token for Mapbox SDK is described [here](https://docs.
 
 The SPM command doesn't support testing on a specified destination, like "iOS, iOS, tvOS Simulator or macOS" when creating this document. The recommended way is to use the "xcodebuild" command when used from the command line.
 
+## Initializing Git submodules
+
+After checking out the repository you must first initialize the Git submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
 ## Running tests from the command line
 
 To run tests, you have to configure the download token for the Mapbox described [here](https://docs.mapbox.com/ios/search/guides/install/#configure-credentials) and then set environment variables:

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,8 @@ let package = Package(
             name: "PublisherTests",
             dependencies: [
                 "AblyAssetTrackingPublisher"
-            ]),
+            ],
+            resources: [.copy("common")]),
         .testTarget(
             name: "InternalTests",
             dependencies: [

--- a/Tests/PublisherTests/CommonResources.swift
+++ b/Tests/PublisherTests/CommonResources.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum CommonResources {
+    static func url(forTestResourceJson name: String?, subdirectory subpath: String?) -> URL? {
+        let moduleBundleSubdirectory = ("common/test-resources" as NSString).appendingPathComponent(subpath ?? "")
+        return Bundle.module.url(forResource: name, withExtension: "json", subdirectory: moduleBundleSubdirectory)
+    }
+}

--- a/Tests/PublisherTests/LocationHistoryDataTests.swift
+++ b/Tests/PublisherTests/LocationHistoryDataTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import AblyAssetTrackingPublisher
+
+final class LocationHistoryDataTests: XCTestCase {
+    func testVersion() {
+        let locationHistoryData = LocationHistoryData(events: [])
+        
+        XCTAssertEqual(locationHistoryData.version, 1)
+    }
+    
+    func testDecodable_decodesTestResource_validAndroid() throws {
+        let jsonFileUrl = try XCTUnwrap(CommonResources.url(forTestResourceJson: "valid-android", subdirectory: "geo/location-history-data"))
+        let jsonData = try Data(contentsOf: jsonFileUrl)
+        
+        let decoder = JSONDecoder()
+        let _ = try decoder.decode(LocationHistoryData.self, from: jsonData)
+    }
+}

--- a/Tests/PublisherTests/common
+++ b/Tests/PublisherTests/common
@@ -1,0 +1,1 @@
+../../external/common


### PR DESCRIPTION
This adds a couple of basic tests for `LocationHistoryData`. It adds the [ably-asset-tracking-common repo](https://github.com/ably/ably-asset-tracking-common/) as a submodule so that we can make use of the JSON test resources contained there. See commit messages for more details.