### PR TITLE
Update `MapboxNavigation` to 2.9.0

### DIFF
--- a/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-common-ios.git",
         "state": {
           "branch": null,
-          "revision": "94505a90242f621ac537f9a275bbd0b4deb5a64e",
-          "version": "23.0.0"
+          "revision": "dbb2e33e29ba3bb75b9f63673504a5847c8c6e24",
+          "version": "23.1.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-core-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "d10cd7b364d29caa4366dddd990b0f5c3cba113d",
-          "version": "10.8.0"
+          "revision": "90d62869c8bde5c10dc5f4f6c1cff40d1b4b79b3",
+          "version": "10.9.0"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "2bbd4e385ff7b3edd5022212c0f77d2474fc08c8",
-          "version": "2.7.0"
+          "revision": "2f91fad31087e6c66bd7cc65f31095babb038493",
+          "version": "2.8.0"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-maps-ios.git",
         "state": {
           "branch": null,
-          "revision": "cc0f7d86b42194e3872b76a0184fd58064e29f10",
-          "version": "10.8.1"
+          "revision": "b7487261707f45ab199928fe189f2aa646a5936b",
+          "version": "10.9.0"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-ios.git",
         "state": {
           "branch": null,
-          "revision": "b2da981652bff257438fe153f14a478f268b433d",
-          "version": "2.8.0"
+          "revision": "63a7d36f241c71799521bd0a6e12838619b38207",
+          "version": "2.9.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "6d15299dc45e4b2ca956247b27fc31528a1c95f0",
-          "version": "115.0.1"
+          "revision": "c29035bf1f77029a71bb8f8973da4e60d2381d38",
+          "version": "119.0.1"
         }
       },
       {
@@ -321,8 +321,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dbc07b0a298d642414d3abec59c9eaba1fb3367f",
-          "version": "2.5.0"
+          "revision": "87b5b37108ba9f37f0885b586d8f6355d8240dd8",
+          "version": "2.6.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-directions-swift.git",
         "state": {
           "branch": null,
-          "revision": "2bbd4e385ff7b3edd5022212c0f77d2474fc08c8",
-          "version": "2.7.0"
+          "revision": "2f91fad31087e6c66bd7cc65f31095babb038493",
+          "version": "2.8.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-ios.git",
         "state": {
           "branch": null,
-          "revision": "b1bccccc17bfb3bbbf54397c4e94e405752852da",
-          "version": "2.8.1"
+          "revision": "63a7d36f241c71799521bd0a6e12838619b38207",
+          "version": "2.9.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/mapbox/mapbox-navigation-native-ios.git",
         "state": {
           "branch": null,
-          "revision": "6d15299dc45e4b2ca956247b27fc31528a1c95f0",
-          "version": "115.0.1"
+          "revision": "c29035bf1f77029a71bb8f8973da4e60d2381d38",
+          "version": "119.0.1"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/mapbox/turf-swift.git",
         "state": {
           "branch": null,
-          "revision": "dbc07b0a298d642414d3abec59c9eaba1fb3367f",
-          "version": "2.5.0"
+          "revision": "87b5b37108ba9f37f0885b586d8f6355d8240dd8",
+          "version": "2.6.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.8.0"),
+        .package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.9.0"),
         .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.16")
     ],
     targets: [


### PR DESCRIPTION
This is so we can use the `HistoryReader` feature (needed for #111).