### PR TITLE
Make sure we have single instances of logger and S3 client in publisher example app

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
@@ -3,11 +3,10 @@ import AblyAssetTrackingCore
 import Logging
 
 class PublisherLogger: AblyAssetTrackingCore.LogHandler {
-    var swiftLog: Logger
+    private let swiftLog: Logger
         
-    init () {
-        swiftLog = Logger(label: "com.ably.PublisherExampleSwiftUI")
-        swiftLog.logLevel = .info
+    init(swiftLog: Logger) {
+        self.swiftLog = swiftLog
     }
     
     func logMessage(level: LogLevel, message: String, error: Error?) {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
@@ -8,12 +8,13 @@ struct PublisherExampleSwiftUIApp: App {
         logger.logLevel = .info
         return logger
     }()
+    @State private var s3Helper = try? S3Helper()
     
     var body: some Scene {
         WindowGroup {
             TabView {
                 NavigationView {
-                    CreatePublisherView(logger: logger)
+                    CreatePublisherView(logger: logger, s3Helper: s3Helper)
                 }
                 .tabItem {
                     Label("Publisher", systemImage: "car")

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
@@ -1,12 +1,19 @@
 import SwiftUI
+import Logging
 
 @main
 struct PublisherExampleSwiftUIApp: App {
+    @State private var logger: Logger = {
+        var logger = Logger(label: "com.ably.PublisherExampleSwiftUI")
+        logger.logLevel = .info
+        return logger
+    }()
+    
     var body: some Scene {
         WindowGroup {
             TabView {
                 NavigationView {
-                    CreatePublisherView()
+                    CreatePublisherView(logger: logger)
                 }
                 .tabItem {
                     Label("Publisher", systemImage: "car")

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
@@ -2,9 +2,10 @@
 
 import SwiftUI
 import AblyAssetTrackingPublisher
+import Logging
 
 struct CreatePublisherView: View {
-    @StateObject private var viewModel = CreatePublisherViewModel()
+    @StateObject private var viewModel: CreatePublisherViewModel
     @State var showConstantAccuracies = false
     @State var showVehicleProfiles = false
     @State var showRoutingProfiles = false
@@ -16,6 +17,10 @@ struct CreatePublisherView: View {
     @State private var error: ErrorInformation?
     @State private var showAlert = false
     @Environment(\.colorScheme) var colorScheme
+        
+    init(logger: Logger) {
+        _viewModel = StateObject(wrappedValue: CreatePublisherViewModel(logger: logger))
+    }
     
     var body: some View {
         VStack {
@@ -197,6 +202,6 @@ struct CreatePublisherView: View {
 
 struct CreatePublisherView_Previews: PreviewProvider {
     static var previews: some View {
-        CreatePublisherView()
+        CreatePublisherView(logger: Logger(label: ""))
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/CreatePublisherView.swift
@@ -18,8 +18,11 @@ struct CreatePublisherView: View {
     @State private var showAlert = false
     @Environment(\.colorScheme) var colorScheme
         
-    init(logger: Logger) {
-        _viewModel = StateObject(wrappedValue: CreatePublisherViewModel(logger: logger))
+    private var s3Helper: S3Helper?
+
+    init(logger: Logger, s3Helper: S3Helper? = nil) {
+        self.s3Helper = s3Helper
+        _viewModel = StateObject(wrappedValue: CreatePublisherViewModel(logger: logger, s3Helper: s3Helper))
     }
     
     var body: some View {
@@ -97,7 +100,7 @@ struct CreatePublisherView: View {
                                 self.showS3Files = true
                             }
                             .sheet(isPresented: $showS3Files) {
-                                S3FilesView(fileName: $viewModel.s3FileName)
+                                S3FilesView(s3Helper: s3Helper, fileName: $viewModel.s3FileName)
                             }
                     }
                     TitleValueListItem(title: "Vehicle Profile", value: viewModel.vehicleProfile.description())

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/S3FilesView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/S3FilesView.swift
@@ -3,7 +3,12 @@ import SwiftUI
 struct S3FilesView: View {
     @Binding var fileName: String?
     @Environment(\.presentationMode) var presentationMode
-    @StateObject private var viewModel = S3FilesViewModel()
+    @StateObject private var viewModel: S3FilesViewModel
+    
+    init(s3Helper: S3Helper? = nil, fileName: Binding<String?>) {
+        _viewModel = StateObject(wrappedValue: S3FilesViewModel(s3Helper: s3Helper))
+        _fileName = fileName
+    }
     
     var body: some View {
         NavigationView {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -14,13 +14,8 @@ class CreatePublisherViewModel: ObservableObject {
         s3Helper != nil
     }
     
-    init(logger: Logger) {
-        do {
-            self.s3Helper = try S3Helper()
-        } catch {
-            self.s3Helper = nil
-        }
-        
+    init(logger: Logger, s3Helper: S3Helper?) {
+        self.s3Helper = s3Helper
         self.logger = logger
     }
     

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -3,21 +3,25 @@
 import Foundation
 import SwiftUI
 import AblyAssetTrackingPublisher
+import Logging
 
 class CreatePublisherViewModel: ObservableObject {
     
     private let s3Helper: S3Helper?
+    private let logger: Logger
     
     private var isS3Available: Bool {
         s3Helper != nil
     }
     
-    init() {
+    init(logger: Logger) {
         do {
             self.s3Helper = try S3Helper()
         } catch {
             self.s3Helper = nil
         }
+        
+        self.logger = logger
     }
     
     @Published var areRawLocationsEnabled: Bool = SettingsModel.shared.areRawLocationsEnabled {
@@ -128,7 +132,7 @@ class CreatePublisherViewModel: ObservableObject {
             .resolutionPolicyFactory(DefaultResolutionPolicyFactory(defaultResolution: resolution))
             .rawLocations(enabled: areRawLocationsEnabled)
             .constantLocationEngineResolution(resolution: constantResolution)
-            .logHandler(handler: PublisherLogger())
+            .logHandler(handler: PublisherLogger(swiftLog: logger))
             .vehicleProfile(vehicleProfile)
             .start()
         

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/S3FilesViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/S3FilesViewModel.swift
@@ -4,13 +4,10 @@ class S3FilesViewModel: ObservableObject {
     @Published var files: [S3Helper.File] = []
     @Published var errorMessage: String?
     @Published var isLoading = false
-    
-    init() {
-        let s3Helper: S3Helper
-        do {
-            s3Helper = try S3Helper()
-        } catch {
-            errorMessage = error.localizedDescription
+        
+    init(s3Helper: S3Helper?) {
+        guard let s3Helper = s3Helper else {
+            self.errorMessage = "S3 is not configured."
             return
         }
 


### PR DESCRIPTION
This creates a single instance of the `Logger` and `S3Client` at the app level (`PublisherExampleSwiftUIApp`) and then injects them throughout. That means that we only have to handle their initialization failure and their configuration once.