### PR TITLE
Build Subscriber SDK in `assemble.sh`

### DIFF
--- a/Scripts/assemble.sh
+++ b/Scripts/assemble.sh
@@ -11,7 +11,7 @@ echo
 echo '\033[1mBuild: AblyAssetTrackingSubscriber Library\033[0m'
 echo
 
-xcodebuild -scheme "AblyAssetTrackingPublisher" -destination "generic/platform=iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+xcodebuild -scheme "AblyAssetTrackingSubscriber" -destination "generic/platform=iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
 
 # Build AblyAssetTrackingPublisher lib
 echo


### PR DESCRIPTION
We were accidentally building the Publisher SDK twice.