### PR TITLE
Turn off library evolution mode in `assemble.sh`

### DIFF
--- a/Scripts/assemble.sh
+++ b/Scripts/assemble.sh
@@ -11,14 +11,14 @@ echo
 echo '\033[1mBuild: AblyAssetTrackingSubscriber Library\033[0m'
 echo
 
-xcodebuild -scheme "AblyAssetTrackingSubscriber" -destination "generic/platform=iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+xcodebuild -scheme "AblyAssetTrackingSubscriber" -destination "generic/platform=iOS" SKIP_INSTALL=NO | xcpretty
 
 # Build AblyAssetTrackingPublisher lib
 echo
 echo '\033[1mBuild: AblyAssetTrackingPublisher Library\033[0m'
 echo
 
-xcodebuild -scheme "AblyAssetTrackingPublisher" -destination "generic/platform=iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+xcodebuild -scheme "AblyAssetTrackingPublisher" -destination "generic/platform=iOS" SKIP_INSTALL=NO | xcpretty
 
 # Subscriber Example (swift)
 echo


### PR DESCRIPTION
[Library evolution mode](https://www.swift.org/blog/library-evolution/) is designed for people who distribute binary frameworks (which we don’t). It imposes restrictions on the code you can write.

I’m not sure why we turned it on in the first place; it’s not explained in 7d52c8f nor its containing PR #213. I see no reason for us to use it.

This came to my attention because I was trying to add a dependency on the [`Version` package](https://github.com/mxcl/Version) and was getting strange errors. I noticed that turning off library evolution mode stopped these errors. Since we have no need for library evolution mode, let’s just turn it off.