### PR TITLE
Publisher example: Store new routing profile in `ObservablePublisher`

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
@@ -41,7 +41,11 @@ class ObservablePublisher: ObservableObject {
     }
     
     func changeRoutingProfile(profile: RoutingProfile, completion: @escaping ResultHandler<Void>) {
-        publisher.changeRoutingProfile(profile: profile, completion: completion)
+        publisher.changeRoutingProfile(profile: profile) { [weak self] result in
+            guard let self = self else { return }
+            self.routingProfile = self.publisher.routingProfile
+            completion(result)
+        }
     }
     
     private func updateTrackables(latestReceived: Set<Trackable>) {


### PR DESCRIPTION
So that the new value propagates to the UI. I didn’t notice this before because changing routing profile isn’t properly working at the moment, but now that I’ve started fixing it (on another branch) I noticed this.