### PR TITLE
Fix situations where `changeRoutingProfile` doesn’t call its callback

### DIFF
--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -274,8 +274,14 @@ extension DefaultPublisher {
             Self.publisherStoppedCallback(handler: event.resultHandler)
             return
         }
-
-        routeProvider.changeRoutingProfile(to: routingProfile) { [weak self] result in
+        
+        guard let destination = activeTrackable?.destination else {
+            self.routingProfile = event.profile
+            Self.callback(value: Void(), handler: event.resultHandler)
+            return
+        }
+        
+        routeProvider.getRoute(to: destination.toCoreLocationCoordinate2d(), withRoutingProfile: event.profile) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let route):

--- a/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/RouteProvider.swift
@@ -4,7 +4,6 @@ import AblyAssetTrackingCore
 
 protocol RouteProvider {
     func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>)
 }
 
 class DefaultRouteProvider: NSObject, RouteProvider {
@@ -19,18 +18,6 @@ class DefaultRouteProvider: NSObject, RouteProvider {
         directions = Directions(credentials: mapboxConfiguration.getCredentials())
 
         super.init()
-    }
-
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
-        self.routingProfile = routingProfile
-        guard let destination = self.destination,
-              !isCalculating(resultHandler: completion) else {
-            return
-        }
-
-        self.getRoute(to: destination,
-                 withRoutingProfile: routingProfile,
-                 completion: completion)
     }
 
     func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -551,33 +551,93 @@ class DefaultPublisherTests: XCTestCase {
     // MARK: stop
     
     // MARK: ChangeRoutingProfile
-    func testChangeRoutingProfile_called() {
+    func testChangeRoutingProfile_withNoActiveTrackable_updatesRoutingProfile_andCallsCallbackWithSuccess() {
+        let expectation = expectation(description: "changeRoutingProfile completes successfully")
+        
         // Given: Default RoutingProfile set to .driving
         publisher.changeRoutingProfile(profile: .cycling) { result in
             switch result {
             case .success:
-                XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
-                XCTAssertEqual(self.routeProvider.changeRoutingProfileParamRoutingProfile, .cycling)
-            case .failure:
-                XCTFail("Failure callback shouldn't be called")
+                XCTAssertFalse(self.routeProvider.getRouteCalled)
+                XCTAssertEqual(self.publisher.routingProfile, .cycling)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("changeRoutingProfile failed with unexpected error: \(error)")
             }
         }
+        
+        waitForExpectations(timeout: 10)
     }
     
-    func testChangeRoutingProfile_shouldCallGetRouteForDestination() {
-        // Given: Default destination set to:
-        let expectedDestination = LocationCoordinate(latitude: 3.1415, longitude: 2.7182)
+    func testChangeRoutingProfile_withActiveTrackableWithoutDestination_updatesRoutingProfile_andCallsCallbackWithSuccess() {
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
+
+        let trackExpectation = expectation(description: "track completes successfully")
         
+        publisher.track(trackable: .init(id: UUID().uuidString)) { result in
+            switch result {
+            case .success:
+                trackExpectation.fulfill()
+            case let .failure(error):
+                XCTFail("changeRoutingProfile failed with unexpected error: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        let changeRoutingProfileExpectation = expectation(description: "changeRoutingProfile completes successfully")
+        
+        // Given: Default RoutingProfile set to .driving
         publisher.changeRoutingProfile(profile: .cycling) { result in
             switch result {
             case .success:
-                XCTAssertTrue(self.routeProvider.changeRoutingProfileCalled)
-                XCTAssertTrue(self.routeProvider.getRouteCalled)
-                XCTAssertEqual(self.routeProvider.getRouteParamDestination?.toLocationCoordinate(), expectedDestination)
+                XCTAssertFalse(self.routeProvider.getRouteCalled)
+                XCTAssertEqual(self.publisher.routingProfile, .cycling)
+                changeRoutingProfileExpectation.fulfill()
             case .failure:
                 XCTFail("Failure callback shouldn't be called")
             }
         }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testChangeRoutingProfile_withActiveTrackableWithDestination_callsGetRouteOnRouteProvider_andWhenThatSucceeds_itUpdatesRoutingProfile_andCallsCallbackWithSuccess() {
+        ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
+        routeProvider.getRouteBody = { handler in handler(.success(.init(legs: [], shape: nil, distance: .infinity, expectedTravelTime: 0))) }
+
+        let trackExpectation = expectation(description: "track completes successfully")
+        
+        let destination = LocationCoordinate(latitude: 3.1415, longitude: 2.7182)
+        
+        publisher.track(trackable: .init(id: UUID().uuidString, destination: destination)) { result in
+            switch result {
+            case .success:
+                trackExpectation.fulfill()
+            case let .failure(error):
+                XCTFail("track failed with unexpected error: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
+        
+        let changeRoutingProfileExpectation = expectation(description: "changeRoutingProfile completes successfully")
+        
+        // Given: Default RoutingProfile set to .driving
+        publisher.changeRoutingProfile(profile: .cycling) { result in
+            switch result {
+            case .success:
+                XCTAssertTrue(self.routeProvider.getRouteCalled)
+                XCTAssertEqual(self.routeProvider.getRouteParamDestination, destination.toCoreLocationCoordinate2d())
+                XCTAssertEqual(self.routeProvider.getRouteParamRoutingProfile, .cycling)
+                XCTAssertEqual(self.publisher.routingProfile, .cycling)
+                changeRoutingProfileExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("changeRoutingProfile failed with unexpected error: \(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 10)
     }
     
     func test_closeConnection_success() {

--- a/Tests/PublisherTests/Mocks/MockRouteProvider.swift
+++ b/Tests/PublisherTests/Mocks/MockRouteProvider.swift
@@ -8,19 +8,12 @@ class MockRouteProvider: RouteProvider{
     var getRouteParamDestination: CLLocationCoordinate2D?
     var getRouteParamRoutingProfile: RoutingProfile?
     var getRouteParamResultHandler: ResultHandler<Route>?
+    var getRouteBody: ((ResultHandler<Route>) -> Void)?
     func getRoute(to destination: CLLocationCoordinate2D, withRoutingProfile routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
         getRouteCalled = true
         getRouteParamDestination = destination
         getRouteParamRoutingProfile = routingProfile
         getRouteParamResultHandler = completion
-    }
-    
-    var changeRoutingProfileCalled: Bool = false
-    var changeRoutingProfileParamRoutingProfile: RoutingProfile?
-    var changeRoutingProfileParamResultHandler: ResultHandler<Route>?
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
-        changeRoutingProfileCalled = true
-        changeRoutingProfileParamRoutingProfile = routingProfile
-        changeRoutingProfileParamResultHandler = completion
+        getRouteBody?(completion)
     }
 }

--- a/Tests/SystemTests/Mocks/MockRouteProvider.swift
+++ b/Tests/SystemTests/Mocks/MockRouteProvider.swift
@@ -14,13 +14,4 @@ class MockRouteProvider: RouteProvider{
         getRouteParamRoutingProfile = routingProfile
         getRouteParamResultHandler = completion
     }
-    
-    var changeRoutingProfileCalled: Bool = false
-    var changeRoutingProfileParamRoutingProfile: RoutingProfile?
-    var changeRoutingProfileParamResultHandler: ResultHandler<Route>?
-    func changeRoutingProfile(to routingProfile: RoutingProfile, completion: @escaping ResultHandler<Route>) {
-        changeRoutingProfileCalled = true
-        changeRoutingProfileParamRoutingProfile = routingProfile
-        changeRoutingProfileParamResultHandler = completion
-    }
 }


### PR DESCRIPTION
In situations where there either was no active trackable, or the active trackable had no destination, the completion handler of `changeRoutingProfile(profile:completion:)` would not be called.

This fixes that by making sure that we always call the callback. In the case where there is no active trackable with a destination, we simply update the publisher’s routing profile and call the callback immediately. This is consistent with the behaviour on Android, [as described by Kacper](https://github.com/ably/ably-asset-tracking-swift/pull/458#discussion_r1029048629).

Our existing tests for this method didn’t catch this because they weren’t actually waiting for the callback, and so none of their assertions were executed. So I’ve fixed those tests and added some more.

The fact that the tests’ assertions weren’t being called also hid another issue with `DefaultPublisher` – namely, that it was ignoring the routing profile that was passed to `changeRoutingProfile`. I’ve fixed this, too.

Closes #420.