### PR TITLE
Add ability to retry uploads in publisher example app

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Helper/S3Helper.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Helper/S3Helper.swift
@@ -60,8 +60,8 @@ class S3Helper {
         return object
     }
     
-    func upload(_ request: UploadRequest) async throws -> Void {
-        let data = try JSONEncoder().encode(request.data)
+    func upload(_ request: UploadRequest, dataFileURL: URL) async throws -> Void {
+        let data = try Data(contentsOf: dataFileURL)
         try await Amplify.Storage.uploadData(key: request.filename, data: data)
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/Upload.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/Upload.swift
@@ -1,19 +1,19 @@
 import Foundation
 
-struct Upload: Identifiable {
-    var id = UUID()
+struct Upload: Identifiable, Codable {
+    var id: UUID
     var request: UploadRequest
     
-    enum Status: CustomStringConvertible {
+    enum Status: CustomStringConvertible, Codable {
         case uploading
         case uploaded
-        case failed(Error)
+        case failed(String)
         
         var description: String {
             switch self {
             case .uploading: return "Uploading"
             case .uploaded: return "Uploaded"
-            case .failed(let error): return "Failed: \(error.localizedDescription)"
+            case .failed(let errorDescription): return "Failed: \(errorDescription)"
             }
         }
     }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadRequest.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadRequest.swift
@@ -1,8 +1,19 @@
 import Foundation
 import AblyAssetTrackingPublisher
 
-struct UploadRequest {
-    var data: LocationHistoryData
+struct UploadRequest: Codable {
+    enum UploadType: CustomStringConvertible, Codable {
+        case locationHistoryData(archiveVersion: String)
+        
+        var description: String {
+            switch self {
+            case .locationHistoryData:
+                return "Location history data"
+            }
+        }
+    }
+    
+    var type: UploadType
     var generatedAt: Date
     
     private static let dateFormatter: DateFormatter = {
@@ -14,7 +25,10 @@ struct UploadRequest {
     }()
     
     var filename: String {
-        let formattedDate = Self.dateFormatter.string(from: generatedAt)
-        return "\(LocationHistoryData.archiveVersion)_\(formattedDate)"
+        switch type {
+        case let .locationHistoryData(archiveVersion):
+            let formattedDate = Self.dateFormatter.string(from: generatedAt)
+            return "\(archiveVersion)_\(formattedDate)"
+        }
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
@@ -4,13 +4,67 @@ import AblyAssetTrackingPublisher
 import Logging
 
 class UploadsManager: ObservableObject {
-    @MainActor @Published private(set) var uploads: [Upload] = []
+    @MainActor @Published private(set) var uploads: [Upload]
     private let s3Helper: S3Helper?
     private let logger: Logger
     
-    init(s3Helper: S3Helper?, logger: Logger) {
+    @MainActor init(s3Helper: S3Helper?, logger: Logger) {
+        do {
+            self.uploads = try Storage.allUploads
+        } catch {
+            logger.error("Failed to load uploads: \(error)")
+            self.uploads = []
+        }
         self.s3Helper = s3Helper
         self.logger = logger
+    }
+    
+    enum Storage {
+        private static let fileManager = FileManager.default
+        
+        static var allUploads: [Upload] {
+            get throws {
+                let contents = try fileManager.contentsOfDirectory(at: try uploadsDirectoryURL, includingPropertiesForKeys: nil)
+                
+                return try contents.map { url in
+                    let uploadId = url.lastPathComponent
+                    let storageDirectoryURL = try Storage.storageDirectoryURL(forUploadId: uploadId)
+                    let metadataURL = Storage.metadataURL(forStorageDirectoryURL: storageDirectoryURL)
+                    let metadata = try Data(contentsOf: metadataURL)
+                    
+                    let decoder = JSONDecoder()
+                    return try decoder.decode(Upload.self, from: metadata)
+                }
+            }
+        }
+        
+        static func ensureStorageDirectoryExists(atURL storageDirectoryURL: URL) throws {
+            if !fileManager.fileExists(atPath: storageDirectoryURL.path, isDirectory: nil) {
+                try fileManager.createDirectory(at: storageDirectoryURL, withIntermediateDirectories: true)
+            }
+        }
+        
+        static var uploadsDirectoryURL: URL {
+            get throws {
+                let applicationSupportURL = try fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+                
+                return applicationSupportURL
+                    .appendingPathComponent("com.ably.tracking.example.publisher")
+                    .appendingPathComponent("uploads")
+            }
+        }
+        
+        static func storageDirectoryURL(forUploadId uploadId: String) throws -> URL {
+            return try uploadsDirectoryURL.appendingPathComponent(uploadId)
+        }
+        
+        static func metadataURL(forStorageDirectoryURL storageDirectoryURL: URL) -> URL {
+            return storageDirectoryURL.appendingPathComponent("upload")
+        }
+        
+        static func dataURL(forStorageDirectoryURL storageDirectoryURL: URL) -> URL {
+            return storageDirectoryURL.appendingPathComponent("data")
+        }
     }
     
     @MainActor func upload(locationHistoryData: LocationHistoryData) {
@@ -19,18 +73,38 @@ class UploadsManager: ObservableObject {
             return
         }
         
-        let request = UploadRequest(data: locationHistoryData, generatedAt: Date())
+        let uploadId = UUID()
+        let dataFileURL: URL
+        do {
+            let storageDirectoryURL = try Storage.storageDirectoryURL(forUploadId: uploadId.uuidString)
+            try Storage.ensureStorageDirectoryExists(atURL: storageDirectoryURL)
+            dataFileURL = Storage.dataURL(forStorageDirectoryURL: storageDirectoryURL)
+            
+            let data = try JSONEncoder().encode(locationHistoryData)
+            try data.write(to: dataFileURL)
+            logger.debug("Wrote location history data to file: \(dataFileURL.path)")
+        } catch {
+            logger.error("Failed to write location history data to file: \(error)")
+            return
+        }
         
-        let upload = Upload(request: request, status: .uploading)
+        let request = UploadRequest(type: .locationHistoryData(archiveVersion: LocationHistoryData.archiveVersion), generatedAt: Date())
+        
+        let upload = Upload(id: uploadId, request: request, status: .uploading)
         logger.info("Starting upload \(upload.id) of location history data")
         uploads.insert(upload, at: 0)
+        do {
+            try saveUpload(upload)
+        } catch {
+            logger.error("Failed to save upload \(upload.id): \(error)")
+        }
         
         Task {
             do {
-                try await s3Helper.upload(request)
+                try await s3Helper.upload(request, dataFileURL: dataFileURL)
             } catch {
                 logger.error("Upload \(upload.id) of location history data failed: \(error.localizedDescription)")
-                updateStatus(forUploadWithId: upload.id, status: .failed(error))
+                updateStatus(forUploadWithId: upload.id, status: .failed(error.localizedDescription))
                 return
             }
             
@@ -44,6 +118,22 @@ class UploadsManager: ObservableObject {
             return
         }
         
-        uploads[index].status = status
+        var upload = uploads[index]
+        upload.status = status
+        uploads[index] = upload
+        do {
+            try saveUpload(upload)
+        } catch {
+            logger.error("Failed to save upload \(upload.id): \(error)")
+        }
+    }
+    
+    private func saveUpload(_ upload: Upload) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(upload)
+        
+        let storageDirectoryURL = try Storage.storageDirectoryURL(forUploadId: upload.id.uuidString)
+        let metadataURL = Storage.metadataURL(forStorageDirectoryURL: storageDirectoryURL)
+        try data.write(to: metadataURL)
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/PublisherExampleSwiftUIApp.swift
@@ -43,7 +43,9 @@ struct PublisherExampleSwiftUIApp: App {
                 */
                 .navigationViewStyle(.stack)
                 NavigationView {
-                    SettingsView(uploads: uploadsManager.uploads)
+                    SettingsView(uploads: uploadsManager.uploads, retry: { upload in
+                        uploadsManager.retry(upload)
+                    })
                 }
                 // Same comment as above
                 .navigationViewStyle(.stack)

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
     @State var showDefaultAccuracies = false
     var uploads: [Upload]
+    var retry: (Upload) -> Void
     
     var body: some View {
         List {
@@ -37,7 +38,9 @@ struct SettingsView: View {
                 }
                 
                 NavigationLink("Uploads") {
-                    UploadsView(uploads: uploads)
+                    UploadsView(uploads: uploads, retry: { upload in
+                        retry(upload)
+                    })
                 }
             } header: {
                 Text("Other settings")
@@ -57,6 +60,6 @@ struct SettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         let upload = Upload(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading)
-        SettingsView(uploads: [upload])
+        SettingsView(uploads: [upload]) { _ in }
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
@@ -56,7 +56,7 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        let upload = Upload(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading)
+        let upload = Upload(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading)
         SettingsView(uploads: [upload])
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
@@ -7,6 +7,8 @@ struct UploadView: View {
         VStack(alignment: .leading) {
             Text("📄 \(upload.request.filename)")
                 .fontWeight(.bold)
+            Text(String(describing: upload.request.type))
+                .italic()
             HStack {
                 Text(String(describing: upload.status))
             }
@@ -16,6 +18,6 @@ struct UploadView: View {
 
 struct UploadView_Previews: PreviewProvider {
     static var previews: some View {
-        UploadView(upload: .init(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading))
+        UploadView(upload: .init(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading))
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct UploadView: View {
     var upload: Upload
+    var retry: () -> Void
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -11,6 +12,13 @@ struct UploadView: View {
                 .italic()
             HStack {
                 Text(String(describing: upload.status))
+                if case .failed = upload.status {
+                    Button() {
+                        retry()
+                    } label: {
+                        Text("Retry")
+                    }
+                }
             }
         }
     }
@@ -18,6 +26,6 @@ struct UploadView: View {
 
 struct UploadView_Previews: PreviewProvider {
     static var previews: some View {
-        UploadView(upload: .init(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading))
+        UploadView(upload: .init(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading)) {}
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
@@ -14,7 +14,7 @@ struct UploadsView: View {
 struct UploadsView_Previews: PreviewProvider {
     static var previews: some View {
         let uploads = (1...10).map { _ in
-            Upload(request: .init(data: .init(events: []), generatedAt: Date()), status: .uploading)
+            Upload(id: UUID(), request: .init(type: .locationHistoryData(archiveVersion: ""), generatedAt: Date()), status: .uploading)
         }
         
         NavigationView {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Uploads/UploadsView.swift
@@ -2,10 +2,13 @@ import SwiftUI
 
 struct UploadsView: View {
     var uploads: [Upload]
+    var retry: (Upload) -> Void
     
     var body: some View {
         List(uploads.sorted(by: { $0.request.generatedAt > $1.request.generatedAt })) { upload in
-            UploadView(upload: upload)
+            UploadView(upload: upload, retry: {
+                retry(upload)
+            })
         }
         .navigationTitle("Uploads")
     }
@@ -18,7 +21,7 @@ struct UploadsView_Previews: PreviewProvider {
         }
         
         NavigationView {
-            UploadsView(uploads: uploads)
+            UploadsView(uploads: uploads) { _ in }
         }
     }
 }


### PR DESCRIPTION
**Note: this is based on #477, please review that one first.**

This persists all of the `LocationHistoryData` uploads that we try to perform, and adds a button for retrying a failed upload.

Here's a video of it in action (the code highlighted at the beginning is for simulating an error in the S3 upload):

https://user-images.githubusercontent.com/53756884/203615904-d28e6135-55a6-4363-92a1-44254f519e21.mov

Closes #475.