### PR TITLE
Publisher example app: Make sure upload ends up in `failed` state after failure

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadsManager.swift
@@ -31,6 +31,7 @@ class UploadsManager: ObservableObject {
             } catch {
                 logger.error("Upload \(upload.id) of location history data failed: \(error.localizedDescription)")
                 updateStatus(forUploadWithId: upload.id, status: .failed(error))
+                return
             }
             
             logger.info("Upload \(upload.id) of location history data succeeded.")


### PR DESCRIPTION
It’s currently falling through to the success case – a mistake in 19457a3.