### PR TITLE
Emit and upload raw Mapbox location history data

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
@@ -1,5 +1,6 @@
 import Combine
 import AblyAssetTrackingPublisher
+import Foundation
 
 class ObservablePublisher: ObservableObject {
     private let publisher: AblyAssetTrackingPublisher.Publisher
@@ -89,5 +90,10 @@ extension ObservablePublisher: PublisherDelegate {
     
     func publisher(sender: AblyAssetTrackingPublisher.Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData) {
         locationHistoryDataHandler?.handleLocationHistoryData(locationHistoryData)
+    }
+    
+    // As mentioned in the documentation for this delegate method, this is an experimental Ably-only API that we are using to debug the Asset Tracking (in this case, we upload the raw location history data to S3 for analysis by the Mapbox team).
+    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didFinishRecordingRawMapboxDataToTemporaryFile temporaryFile: TemporaryFile) {
+        locationHistoryDataHandler?.handleRawMapboxData(inTemporaryFile: temporaryFile)
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/LocationHistoryUploader.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/LocationHistoryUploader.swift
@@ -3,6 +3,7 @@ import Foundation
 
 protocol LocationHistoryDataHandlerProtocol {
     func handleLocationHistoryData(_ locationHistoryData: LocationHistoryData)
+    func handleRawMapboxData(inTemporaryFile temporaryFile: TemporaryFile)
 }
 
 class LocationHistoryDataUploader: LocationHistoryDataHandlerProtocol {
@@ -15,6 +16,12 @@ class LocationHistoryDataUploader: LocationHistoryDataHandlerProtocol {
     func handleLocationHistoryData(_ locationHistoryData: LocationHistoryData) {
         Task { @MainActor in
             uploadsManager.upload(locationHistoryData: locationHistoryData)
+        }
+    }
+    
+    func handleRawMapboxData(inTemporaryFile temporaryFile: TemporaryFile) {
+        Task { @MainActor in
+            uploadsManager.uploadRawMapboxData(inTemporaryFile: temporaryFile)
         }
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadRequest.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/Uploads/UploadRequest.swift
@@ -4,11 +4,14 @@ import AblyAssetTrackingPublisher
 struct UploadRequest: Codable {
     enum UploadType: CustomStringConvertible, Codable {
         case locationHistoryData(archiveVersion: String)
+        case rawMapboxHistory(originalFilename: String)
         
         var description: String {
             switch self {
             case .locationHistoryData:
                 return "Location history data"
+            case .rawMapboxHistory:
+                return "Raw Mapbox history"
             }
         }
     }
@@ -25,10 +28,13 @@ struct UploadRequest: Codable {
     }()
     
     var filename: String {
+        let formattedDate = Self.dateFormatter.string(from: generatedAt)
+
         switch type {
         case let .locationHistoryData(archiveVersion):
-            let formattedDate = Self.dateFormatter.string(from: generatedAt)
             return "\(archiveVersion)_\(formattedDate)"
+        case let .rawMapboxHistory(originalFilename):
+            return "RawMapboxHistory/\(formattedDate)_\(originalFilename)"
         }
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -213,6 +213,8 @@ extension DefaultPublisher {
                 self.delegate?.publisher(sender: self, didUpdateEnhancedLocation: event.locationUpdate)
             case .finishedRecordingLocationHistoryData(let event):
                 self.delegate?.publisher(sender: self, didFinishRecordingLocationHistoryData: event.locationHistoryData)
+            case .finishedRecordingRawMapboxData(let event):
+                self.delegate?.publisher(sender: self, didFinishRecordingRawMapboxDataToTemporaryFile: event.temporaryFile)
             }
         }
     }
@@ -384,9 +386,10 @@ extension DefaultPublisher {
             switch result {
             case .failure(let error):
                 self.logHandler?.error(message: "\(Self.self): Failed to stop recording location", error: error)
-            case .success(let locationHistoryData):
-                if let locationHistoryData = locationHistoryData {
-                    self.sendDelegateEvent(.finishedRecordingLocationHistoryData(.init(locationHistoryData: locationHistoryData)))
+            case .success(let locationRecordingResult):
+                if let locationRecordingResult = locationRecordingResult {
+                    self.sendDelegateEvent(.finishedRecordingLocationHistoryData(.init(locationHistoryData: locationRecordingResult.locationHistoryData)))
+                    self.sendDelegateEvent(.finishedRecordingRawMapboxData(.init(temporaryFile: locationRecordingResult.rawHistoryFile)))
                 }
             }
                         

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
@@ -159,6 +159,8 @@ extension DefaultPublisher {
         case enhancedLocationChanged(EnhancedLocationChangedEvent)
         case trackableConnectionStateChanged(TrackableConnectionStateChangedEvent)
         case finishedRecordingLocationHistoryData(FinishedRecordingLocationHistoryDataEvent)
+        case finishedRecordingRawMapboxData(FinishedRecordingRawMapboxDataEvent)
+
         
         struct ErrorEvent {
             let error: ErrorInformation
@@ -175,6 +177,10 @@ extension DefaultPublisher {
         
         struct FinishedRecordingLocationHistoryDataEvent {
             let locationHistoryData: LocationHistoryData
+        }
+        
+        struct FinishedRecordingRawMapboxDataEvent {
+            let temporaryFile: TemporaryFile
         }
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -52,6 +52,13 @@ public protocol PublisherDelegate: AnyObject {
      Called when the publisher has finished recording location history data, to expose the data that it recorded. The publisher will call this method after it receives the ``Publisher/stop(completion:)`` method call and before that method’s completion handler is called. It will only do so if at least one trackable was added to the publisher during its lifetime.
      */
     func publisher(sender: Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData)
+    
+    /**
+     Called when the publisher has finished recording location history data, to expose the raw history data emitted by the Mapbox SDK. The publisher will call this method if and only if it calls the ``publisher(sender:didFinishRecordingLocationHistoryData:)`` method; see the documentation for that method for more information on the circumstances in which it is called.
+     
+     - Important: This delegate method should be considered an experimental API, which may be removed or changed at any time. It is currently only intended to be used internally by Ably for debugging.
+     */
+    func publisher(sender: Publisher, didFinishRecordingRawMapboxDataToTemporaryFile temporaryFile: TemporaryFile)
 }
 
 public extension PublisherDelegate {
@@ -59,4 +66,8 @@ public extension PublisherDelegate {
      Default implementation to make this method `optional`
      */
     func publisher(sender: Publisher, didFinishRecordingLocationHistoryData locationHistoryData: LocationHistoryData) {}
+    /**
+     Default implementation to make this method `optional`
+     */
+    func publisher(sender: Publisher, didFinishRecordingRawMapboxDataToTemporaryFile temporaryFile: TemporaryFile) {}
 }

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
@@ -103,7 +103,7 @@ class DefaultLocationService: LocationService {
         PassiveLocationManager.startRecordingHistory()
     }
     
-    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>) {
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationRecordingResult?>) {
         PassiveLocationManager.stopRecordingHistory { [weak self] historyFileURL in
             self?.workQueue.async { [weak self] in
                 guard let self = self else {
@@ -142,15 +142,8 @@ class DefaultLocationService: LocationService {
                     return
                 }
                 
-                do {
-                    try FileManager.default.removeItem(at: historyFileURL)
-                } catch {
-                    self.logHandler?.error(message: "\(Self.self): Failed to delete history file at \(historyFileURL)", error: error)
-                    completion(.failure(.init(error: error)))
-                    return
-                }
-                
-                completion(.success(locationHistoryData))
+                let rawHistoryTemporaryFile = TemporaryFile(fileURL: historyFileURL, logHandler: self.logHandler)
+                completion(.success(.init(locationHistoryData: locationHistoryData, rawHistoryFile: rawHistoryTemporaryFile)))
             }
         }
     }

--- a/Sources/AblyAssetTrackingPublisher/Services/LocationService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/LocationService.swift
@@ -7,11 +7,16 @@ protocol LocationServiceDelegate: AnyObject {
     func locationService(sender: LocationService, didUpdateRawLocationUpdate locationUpdate: RawLocationUpdate)
 }
 
+struct LocationRecordingResult {
+    var locationHistoryData: LocationHistoryData
+    var rawHistoryFile: TemporaryFile
+}
+
 protocol LocationService: AnyObject {
     var delegate: LocationServiceDelegate? { get set }
     func startUpdatingLocation()
     func stopUpdatingLocation()
     func startRecordingLocation()
-    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>)
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationRecordingResult?>)
     func changeLocationEngineResolution(resolution: Resolution)
 }

--- a/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
+++ b/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
@@ -1,0 +1,35 @@
+import Foundation
+import AblyAssetTrackingCore
+
+/// A reference to a temporary file which will be deleted once there are no remaining strong references to this object.
+public final class TemporaryFile {
+    public let fileURL: URL
+    private let logHandler: LogHandler?
+    // For testing this class.
+    private let didDeleteCallback: (() -> Void)?
+    private static let cleanupQueue = DispatchQueue(label: "com.ably.AssetTracking.TemporaryFile.cleanupQueue", qos: .background)
+    
+    init(fileURL: URL, logHandler: LogHandler?, didDeleteCallback: (() -> Void)? = nil) {
+        self.fileURL = fileURL
+        self.logHandler = logHandler
+        self.didDeleteCallback = didDeleteCallback
+    }
+    
+    /// Executes the block and ensures that the file at ``fileURL`` will not be deleted during its execution.
+    public func stayAlive(whilstExecuting action: () throws -> Void) rethrows {
+        // (Here I’m relying on my belief that an object won’t be deallocated during the execution of one of its instance methods.)
+        try action()
+    }
+    
+    deinit {
+        Self.cleanupQueue.async { [fileURL, logHandler, didDeleteCallback] in
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+                logHandler?.debug(message: "\(Self.self): Removed file at \(fileURL)", error: nil)
+                didDeleteCallback?()
+            } catch {
+                logHandler?.error(message: "\(Self.self): Failed to remove file at \(fileURL)", error: error)
+            }
+        }
+    }
+}

--- a/Tests/PublisherTests/Mocks/MockLocationService.swift
+++ b/Tests/PublisherTests/Mocks/MockLocationService.swift
@@ -31,9 +31,9 @@ class MockLocationService: LocationService {
     }
     
     var stopRecordingLocationCalled = false
-    var stopRecordingLocationParamCompletion: ResultHandler<LocationHistoryData?>?
-    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationHistoryData?>) -> Void)?
-    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>) {
+    var stopRecordingLocationParamCompletion: ResultHandler<LocationRecordingResult?>?
+    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationRecordingResult?>) -> Void)?
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationRecordingResult?>) {
         stopRecordingLocationCalled = true
         stopRecordingLocationParamCompletion = completion
         stopRecordingLocationCallback?(completion)

--- a/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
+++ b/Tests/PublisherTests/Mocks/MockPublisherDelegate.swift
@@ -71,4 +71,15 @@ class MockPublisherDelegate: PublisherDelegate {
         publisherDidFinishRecordingLocationHistoryDataParamLocationHistoryData = locationHistoryData
         publisherDidFinishRecordingLocationHistoryDataCallback?()
     }
+    
+    var publisherDidFinishRecordingRawMapboxDataToTemporaryFileCalled: Bool = false
+    var publisherDidFinishRecordingRawMapboxDataToTemporaryFileParamSender: Publisher?
+    var publisherDidFinishRecordingRawMapboxDataToTemporaryFileParamTemporaryFile: TemporaryFile?
+    var publisherDidFinishRecordingRawMapboxDataToTemporaryFileCallback: (() -> Void)?
+    func publisher(sender: Publisher, didFinishRecordingRawMapboxDataToTemporaryFile temporaryFile: TemporaryFile) {
+        publisherDidFinishRecordingRawMapboxDataToTemporaryFileCalled = true
+        publisherDidFinishRecordingRawMapboxDataToTemporaryFileParamSender = sender
+        publisherDidFinishRecordingRawMapboxDataToTemporaryFileParamTemporaryFile = temporaryFile
+        publisherDidFinishRecordingRawMapboxDataToTemporaryFileCallback?()
+    }
 }

--- a/Tests/PublisherTests/Storage/File.swift
+++ b/Tests/PublisherTests/Storage/File.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import AblyAssetTrackingPublisher
+
+class TemporaryFileTests: XCTestCase {
+    func testDeinit_removesFile() throws {
+        let fileManager = FileManager.default
+        
+        let temporaryDirectoryURL = fileManager.temporaryDirectory
+        let fileURL = temporaryDirectoryURL.appendingPathComponent(UUID().uuidString)
+        try Data().write(to: fileURL)
+        
+        let expectation = expectation(description: "File is deleted")
+        var temporaryFile: TemporaryFile? = TemporaryFile(fileURL: fileURL, logHandler: nil, didDeleteCallback: {
+            XCTAssertFalse(fileManager.fileExists(atPath: fileURL.path))
+            expectation.fulfill()
+        })
+        
+        _ = temporaryFile // To avoid warning "Variable 'temporaryFile' was written to, but never read"
+        temporaryFile = nil
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testStayAlive_doesntRemoveFileWhilstExecutingAction() throws {
+        let fileManager = FileManager.default
+        
+        let temporaryDirectoryURL = fileManager.temporaryDirectory
+        let fileURL = temporaryDirectoryURL.appendingPathComponent(UUID().uuidString)
+        try Data().write(to: fileURL)
+        
+        let expectation = expectation(description: "stayAlive’s action is executed")
+        TemporaryFile(fileURL: fileURL, logHandler: nil).stayAlive {
+            XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/Tests/SystemTests/Mocks/MockLocationService.swift
+++ b/Tests/SystemTests/Mocks/MockLocationService.swift
@@ -31,9 +31,9 @@ class MockLocationService: LocationService {
     }
     
     var stopRecordingLocationCalled = false
-    var stopRecordingLocationParamCompletion: ResultHandler<LocationHistoryData?>?
-    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationHistoryData?>) -> Void)?
-    func stopRecordingLocation(completion: @escaping ResultHandler<LocationHistoryData?>) {
+    var stopRecordingLocationParamCompletion: ResultHandler<LocationRecordingResult?>?
+    var stopRecordingLocationCallback: ((@escaping ResultHandler<LocationRecordingResult?>) -> Void)?
+    func stopRecordingLocation(completion: @escaping ResultHandler<LocationRecordingResult?>) {
         stopRecordingLocationCalled = true
         stopRecordingLocationParamCompletion = completion
         stopRecordingLocationCallback?(completion)


### PR DESCRIPTION
This closes #478 and closes #479, by adding an API to the publisher SDK to expose the raw Mapbox location history data, and then making the publisher example app upload this data to S3. See commit messages for more details.

Here's a demo of how it looks in the publisher example app:

https://user-images.githubusercontent.com/53756884/203791315-ce792a46-3577-49f7-a6d9-94d99d48d503.mov

