### PR TITLE
Publisher example: Use ISO 8601 (with fractional seconds) timestamp in logs

### DIFF
--- a/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -308,6 +308,15 @@
         }
       },
       {
+        "package": "swift-log-format-and-pipe",
+        "repositoryURL": "https://github.com/Adorkable/swift-log-format-and-pipe",
+        "state": {
+          "branch": null,
+          "revision": "bd29badb9e6b18122ec10b84eed534db83cad279",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "SwiftProtobuf",
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2139286728F783A40073DE99 /* Alert+ErrorInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2139286628F783A40073DE99 /* Alert+ErrorInformation.swift */; };
 		2144B8212908276F00958144 /* SelectDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8202908276F00958144 /* SelectDestinationView.swift */; };
 		2144B8252908278B00958144 /* DestinationMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144B8242908278B00958144 /* DestinationMapView.swift */; };
+		21ABD580293F6D1C0031A34B /* LoggingFormatAndPipe in Frameworks */ = {isa = PBXBuildFile; productRef = 21ABD57F293F6D1C0031A34B /* LoggingFormatAndPipe */; };
 		21AE71A4290B1D6500427F04 /* UploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE71A3290B1D6500427F04 /* UploadsView.swift */; };
 		21AE71A6290B27BE00427F04 /* UploadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AE71A5290B27BE00427F04 /* UploadsManager.swift */; };
 		21B6446B28FDC68C00156F94 /* AddTrackableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B6446A28FDC68C00156F94 /* AddTrackableViewModel.swift */; };
@@ -121,6 +122,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C3E7C3F28BF695000171D14 /* Logging in Frameworks */,
+				21ABD580293F6D1C0031A34B /* LoggingFormatAndPipe in Frameworks */,
 				2108B75729097498002778CA /* Amplify in Frameworks */,
 				D544FB072771B3850015925C /* AblyAssetTrackingPublisher in Frameworks */,
 				2108B75329097498002778CA /* AWSCognitoAuthPlugin in Frameworks */,
@@ -362,6 +364,7 @@
 				2108B75229097498002778CA /* AWSCognitoAuthPlugin */,
 				2108B75429097498002778CA /* AWSS3StoragePlugin */,
 				2108B75629097498002778CA /* Amplify */,
+				21ABD57F293F6D1C0031A34B /* LoggingFormatAndPipe */,
 			);
 			productName = PublisherExampleSwiftUI;
 			productReference = D544FAF22771B3560015925C /* PublisherExampleSwiftUI.app */;
@@ -394,6 +397,7 @@
 			packageReferences = (
 				0C3E7C3D28BF695000171D14 /* XCRemoteSwiftPackageReference "swift-log" */,
 				2108B75129097498002778CA /* XCRemoteSwiftPackageReference "amplify-swift" */,
+				21ABD57E293F6D1C0031A34B /* XCRemoteSwiftPackageReference "swift-log-format-and-pipe" */,
 			);
 			productRefGroup = D544FAF32771B3560015925C /* Products */;
 			projectDirPath = "";
@@ -698,6 +702,14 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		21ABD57E293F6D1C0031A34B /* XCRemoteSwiftPackageReference "swift-log-format-and-pipe" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Adorkable/swift-log-format-and-pipe";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -720,6 +732,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2108B75129097498002778CA /* XCRemoteSwiftPackageReference "amplify-swift" */;
 			productName = Amplify;
+		};
+		21ABD57F293F6D1C0031A34B /* LoggingFormatAndPipe */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 21ABD57E293F6D1C0031A34B /* XCRemoteSwiftPackageReference "swift-log-format-and-pipe" */;
+			productName = LoggingFormatAndPipe;
 		};
 		D544FB062771B3850015925C /* AblyAssetTrackingPublisher */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
I want to be able to easily parse the logs for analysis (hence ISO 8601), and I want to have fractional second accuracy (it currently only logs in seconds).

Picked the log handler library from the list given on the swift-log repo README; seemed like a simple one to use.