### PR TITLE
Don’t put timestamp in the log output

### DIFF
--- a/Sources/AblyAssetTrackingInternal/Logging/LogHandler+Default.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/LogHandler+Default.swift
@@ -3,40 +3,26 @@ import AblyAssetTrackingCore
 
 public extension LogHandler {
     func verbose(message: String, error: Error?) {
-        log(level: .verbose, message: message, error: error)
+        logMessage(level: .verbose, message: message, error: error)
     }
     
     func info(message: String, error: Error?) {
-        log(level: .info, message: message, error: error)
+        logMessage(level: .info, message: message, error: error)
     }
     
     func debug(message: String, error: Error?) {
-        log(level: .debug, message: message, error: error)
+        logMessage(level: .debug, message: message, error: error)
     }
     
     func warn(message: String, error: Error?) {
-        log(level: .warn, message: message, error: error)
+        logMessage(level: .warn, message: message, error: error)
     }
     
     func error(message: String, error: Error?) {
-        log(level: .error, message: message, error: error)
+        logMessage(level: .error, message: message, error: error)
     }
 
     func error(error: Error?) {
-        log(level: .error, message: "", error: error)
-    }
-    
-    private func log(level: LogLevel, message: String, error: Error?) {
-        let timestampString = getFormattedCurrentTimestamp()
-        logMessage(level: level, message: "\(timestampString): \(message)", error: error)
-    }
-    
-    private func getFormattedCurrentTimestamp() -> String{
-        let currentDate = Date()
-        
-        let dateFormatter = DateFormatter()
-        
-        dateFormatter.dateFormat = "dd-MM-yyyy HH:mm:ss.SSS"
-        return dateFormatter.string(from: currentDate)
+        logMessage(level: .error, message: "", error: error)
     }
 }


### PR DESCRIPTION
We leave this to the `LogHandler` implementation, to avoid duplicate timestamps and to give users freedom of choice about how to format their timestamps.