### PR TITLE
Use Sourcery to generate `LogHandler` mock

### DIFF
--- a/.sourcery-CoreMocks.yml
+++ b/.sourcery-CoreMocks.yml
@@ -1,0 +1,9 @@
+sources:
+  - Sources/AblyAssetTrackingCore/Logging/LogHandler.swift
+templates:
+  - Sourcery/templates/AutoMockable.stencil
+output:
+  Tests/Support/AblyAssetTrackingCoreTesting/Mocks/GeneratedMocks.swift
+args:
+  autoMockableImports:
+    - AblyAssetTrackingCore

--- a/Scripts/generate-mocks.sh
+++ b/Scripts/generate-mocks.sh
@@ -14,5 +14,6 @@ run_sourcery () {
   mint run krzysztofzablocki/Sourcery@1.9.2 --config ".sourcery-${1}.yml"
 }
 
+run_sourcery "CoreMocks"
 run_sourcery "InternalMocks"
 run_sourcery "SubscriberMocks"

--- a/Sources/AblyAssetTrackingCore/Logging/LogHandler.swift
+++ b/Sources/AblyAssetTrackingCore/Logging/LogHandler.swift
@@ -3,6 +3,7 @@ import Foundation
 /**
  * Simple protocol that allows to handle logs sent from the SDK.
  */
+//sourcery: AutoMockable
 public protocol LogHandler {
     /**
      * Gets called when a log message is sent from the SDK.

--- a/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
+++ b/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
@@ -6,7 +6,7 @@ import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingInternalTesting
 
 class DefaultAblyTests: XCTestCase {
-    let logger = MockLogHandler()
+    let logger = LogHandlerMock()
 
     func test_connect_whenNotConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itFails() {
         let presence = AblySDKRealtimePresenceMock()

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -21,7 +21,7 @@ class DefaultPublisherTests: XCTestCase {
     var delegate: MockPublisherDelegate!
     var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
     
-    let logger = MockLogHandler()
+    let logger = LogHandlerMock()
     let waitAsync = WaitAsync()
     
     override func setUpWithError() throws {

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -21,7 +21,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     var waitAsync: WaitAsync!
     var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
     var rawLocationState: TrackableState<RawLocationUpdate>!
-    var logger: MockLogHandler!
+    var logger: LogHandlerMock!
     
     override func setUpWithError() throws {
         locationService = MockLocationService()
@@ -34,7 +34,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         waitAsync = WaitAsync()
         enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
         rawLocationState = TrackableState<RawLocationUpdate>()
-        logger = MockLogHandler()
+        logger = LogHandlerMock()
         
         trackable = Trackable(
             id: "TrackableId",

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -96,7 +96,7 @@ class PublisherHelper {
         locationService: LocationService = MockLocationService(),
         routeProvider: RouteProvider = MockRouteProvider(),
         enhancedLocationState: TrackableState<EnhancedLocationUpdate> = TrackableState<EnhancedLocationUpdate>(),
-        logHandler: MockLogHandler = MockLogHandler()
+        logHandler: LogHandlerMock = LogHandlerMock()
     ) -> DefaultPublisher {
         
         DefaultPublisher(

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -12,7 +12,7 @@ class DefaultSubscriberTests: XCTestCase {
     private var trackableId: String!
     
     private let configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
-    private let logger = MockLogHandler()
+    private let logger = LogHandlerMock()
     
     override func setUpWithError() throws {
         trackableId = "Trackable-\(UUID().uuidString)"

--- a/Tests/Support/AblyAssetTrackingCoreTesting/Mocks/GeneratedMocks.swift
+++ b/Tests/Support/AblyAssetTrackingCoreTesting/Mocks/GeneratedMocks.swift
@@ -1,0 +1,58 @@
+// Generated using Sourcery 1.9.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
+
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
+import AblyAssetTrackingCore
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+public class LogHandlerMock: LogHandler {
+
+    public init() {}
+
+
+    //MARK: - logMessage
+
+    public var logMessageLevelMessageErrorCallsCount = 0
+    public var logMessageLevelMessageErrorCalled: Bool {
+        return logMessageLevelMessageErrorCallsCount > 0
+    }
+    public var logMessageLevelMessageErrorReceivedArguments: (level: LogLevel, message: String, error: Error?)?
+    public var logMessageLevelMessageErrorReceivedInvocations: [(level: LogLevel, message: String, error: Error?)] = []
+    public var logMessageLevelMessageErrorClosure: ((LogLevel, String, Error?) -> Void)?
+
+    public func logMessage(level: LogLevel, message: String, error: Error?) {
+        logMessageLevelMessageErrorCallsCount += 1
+        logMessageLevelMessageErrorReceivedArguments = (level: level, message: message, error: error)
+        logMessageLevelMessageErrorReceivedInvocations.append((level: level, message: message, error: error))
+        logMessageLevelMessageErrorClosure?(level, message, error)
+    }
+
+}

--- a/Tests/Support/AblyAssetTrackingCoreTesting/Mocks/MockAblyLogHandler.swift
+++ b/Tests/Support/AblyAssetTrackingCoreTesting/Mocks/MockAblyLogHandler.swift
@@ -1,8 +1,0 @@
-import Foundation
-import AblyAssetTrackingCore
-
-public class MockLogHandler: LogHandler {
-    public init() {}
-    
-    public func logMessage(level: LogLevel, message: String, error: Error?) {}
-}

--- a/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/MockAblySubscriber.swift
+++ b/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/MockAblySubscriber.swift
@@ -9,7 +9,7 @@ public class MockAblySubscriber: AblySubscriber {
         didSet { wasDelegateSet = true }
     }
     
-    let logger = MockLogHandler()
+    let logger = LogHandlerMock()
     
     public var initConnectionConfiguration: ConnectionConfiguration?
     public var initMode: AblyMode?

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -9,7 +9,7 @@ import AblyAssetTrackingPublisherTesting
 class ChannelModesTests: XCTestCase {
     private let defaultDelayTime: TimeInterval = 10.0
     private let didUpdateEnhancedLocationExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Enhanced Locations")
-    let logger = MockLogHandler()
+    let logger = LogHandlerMock()
     
     func testShouldCreateOnlyOnePublisherAndOneSubscriberConnection() throws {
         let subscriberClientId = "Test-Subscriber_\(UUID().uuidString)"

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -32,7 +32,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         "Test-Publisher_\(UUID().uuidString)"
     }()
     
-    private let logger = MockLogHandler()
+    private let logger = LogHandlerMock()
     
     override func setUpWithError() throws { }
     override func tearDownWithError() throws { }


### PR DESCRIPTION
For #494, I want to be able to make assertions about the methods called on a `LogHandler` instance.

**Please note that this PR is based on top of #501; please review that one first.**