### PR TITLE
Add info to log messages about which subsystem emitted message

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -70,11 +70,11 @@ public class DefaultAbly: AblyCommon {
         let channel = client.channels.getChannelFor(trackingId: trackableId, options: options)
         
         if [.detached, .failed].contains(channel.state) {
-            logHandler?.debug(message: "\(String(describing: self.self)): Channel for trackable \(trackableId) is in state \(channel.state); attaching", error: nil)
+            logHandler?.debug(message: "Channel for trackable \(trackableId) is in state \(channel.state); attaching", error: nil)
             channel.attach { [weak self] error in
                 guard let self = self else { return }
                 if let error = error {
-                    self.logHandler?.error(message: "\(String(describing: self.self)): Failed to attach to channel for trackable \(trackableId)", error: error)
+                    self.logHandler?.error(message: "Failed to attach to channel for trackable \(trackableId)", error: error)
                     completion(.failure(error.toErrorInformation()))
                     return
                 }
@@ -95,7 +95,7 @@ public class DefaultAbly: AblyCommon {
                 
         channel.presence.enter(presenceDataJSON) { [weak self] error in
             guard let self = self else { return }
-            self.logHandler?.debug(message: "\(String(describing: Self.self)): Entered a channel [id: \(trackableId)] presence successfully", error: nil)
+            self.logHandler?.debug(message: "Entered a channel [id: \(trackableId)] presence successfully", error: nil)
             
             let presenceEnterSuccess = { [weak self] in
                 self?.channels[trackableId] = channel
@@ -103,7 +103,7 @@ public class DefaultAbly: AblyCommon {
             }
             
             let presenceEnterTerminalFailure = { [weak self] (error: ARTErrorInfo) in
-                self?.logHandler?.error(message: "\(String(describing: Self.self)): Error while joining a channel [id: \(trackableId)] presence", error: error)
+                self?.logHandler?.error(message: "Error while joining a channel [id: \(trackableId)] presence", error: error)
                 completion(.failure(error.toErrorInformation()))
             }
             
@@ -113,23 +113,23 @@ public class DefaultAbly: AblyCommon {
             }
             
             if error.code == ARTErrorCode.operationNotPermittedWithProvidedCapability.rawValue && self.connectionConfiguration.usesTokenAuth {
-                self.logHandler?.debug(message: "\(String(describing: Self.self)): Failed to enter presence on channel [id: \(trackableId)], requesting Ably SDK to re-authorize", error: error)
+                self.logHandler?.debug(message: "Failed to enter presence on channel [id: \(trackableId)], requesting Ably SDK to re-authorize", error: error)
                 self.client.auth.authorize { [weak self] _, error in
                     guard let self = self
                     else { return }
                     if let error = error {
-                        self.logHandler?.error(message: "\(String(describing: Self.self)): Error calling authorize: \(String(describing: error))", error: error)
+                        self.logHandler?.error(message: "Error calling authorize: \(String(describing: error))", error: error)
                         completion(.failure(ErrorInformation(error: error)))
                     } else {
                         // The channel is currently in the FAILED state, so an immediate attempt to enter presence would fail. We need to first of all explicitly attach to the channel to get it out of the FAILED state (if we _were_ able to attempt to enter presence, doing so would attach to the channel anyway, so we’re not doing anything surprising here).
-                        self.logHandler?.debug(message: "\(String(describing: Self.self)): Authorize succeeded, attaching to channel so that we can retry presence enter", error: nil)
+                        self.logHandler?.debug(message: "Authorize succeeded, attaching to channel so that we can retry presence enter", error: nil)
 
                         channel.attach { error in
                             if let error = error {
                                 self.logHandler?.error(message: "Error attaching to channel [id: \(trackableId)]: \(String(describing: error))", error: error)
                                 completion(.failure(ErrorInformation(error: error)))
                             } else {
-                                self.logHandler?.debug(message: "\(String(describing: Self.self)): Channel attach succeeded, retrying presence enter", error: nil)
+                                self.logHandler?.debug(message: "Channel attach succeeded, retrying presence enter", error: nil)
                                 channel.presence.enter(presenceDataJSON) { error in
                                     guard let error = error else {
                                         presenceEnterSuccess()
@@ -162,7 +162,7 @@ public class DefaultAbly: AblyCommon {
         
         channelToRemove.presence.leave(presenceDataJSON) { [weak self] error in
             guard let error = error else {
-                self?.logHandler?.debug(message: "\(String(describing: Self.self)): Left channel [id: \(trackableId)] presence successfully", error: nil)
+                self?.logHandler?.debug(message: "Left channel [id: \(trackableId)] presence successfully", error: nil)
                 channelToRemove.presence.unsubscribe()
                 channelToRemove.unsubscribe()
                 
@@ -173,13 +173,13 @@ public class DefaultAbly: AblyCommon {
                         
                         return
                     }
-                    self?.logHandler?.error(message: "\(String(describing: Self.self)): Error during detach channel [id: \(trackableId)] presence", error: error)
+                    self?.logHandler?.error(message: "Error during detach channel [id: \(trackableId)] presence", error: error)
                     completion(.failure(error.toErrorInformation()))
                 }
                 
                 return
             }
-            self?.logHandler?.error(message: "\(String(describing: Self.self)): Error while leaving the channel [id: \(trackableId)] presence", error: error)
+            self?.logHandler?.error(message: "Error while leaving the channel [id: \(trackableId)] presence", error: error)
             completion(.failure(error.toErrorInformation()))
         }
     }
@@ -192,16 +192,16 @@ public class DefaultAbly: AblyCommon {
             self.disconnect(trackableId: trackableId, presenceData: presenceData) {[weak self] result in
                 switch result {
                 case .success(let wasPresent):
-                    self?.logHandler?.info(message: "\(String(describing: Self.self)): Trackable \(trackableId) removed successfully. Was present \(wasPresent)", error: nil)
+                    self?.logHandler?.info(message: "Trackable \(trackableId) removed successfully. Was present \(wasPresent)", error: nil)
                 case .failure(let error):
-                    self?.logHandler?.error(message: "\(String(describing: Self.self)): Removing trackable \(trackableId) failed", error: error)
+                    self?.logHandler?.error(message: "Removing trackable \(trackableId) failed", error: error)
                 }
                 closingDispatchGroup.leave()
             }
         }
         
         closingDispatchGroup.notify(queue: .main) { [weak self] in
-            self?.logHandler?.info(message: "\(String(describing: Self.self)): All trackables removed.", error: nil)
+            self?.logHandler?.info(message: "All trackables removed.", error: nil)
             self?.closeConnection(completion: completion)
         }
     }
@@ -213,7 +213,7 @@ public class DefaultAbly: AblyCommon {
             }
             
             let receivedConnectionState = stateChange.current.toConnectionState()
-            self.logHandler?.debug(message: "\(String(describing: Self.self)): Connection to Ably changed. New state: \(receivedConnectionState.description)", error: nil)
+            self.logHandler?.debug(message: "Connection to Ably changed. New state: \(receivedConnectionState.description)", error: nil)
             
             self.publisherDelegate?.ablyPublisher(
                 self,
@@ -232,7 +232,7 @@ public class DefaultAbly: AblyCommon {
         }
         
         channel.presence.get { [weak self] messages, error in
-            self?.logHandler?.debug(message: "\(String(describing: Self.self)): Get presence update from channel", error: nil)
+            self?.logHandler?.debug(message: "Get presence update from channel", error: nil)
             guard let self = self, let messages = messages else {
                 return
             }
@@ -243,7 +243,7 @@ public class DefaultAbly: AblyCommon {
         channel.presence.subscribe { [weak self] message in
             guard let self = self else { return }
             
-            self.logHandler?.debug(message: "\(String(describing: Self.self)): Received presence update from channel", error: nil)
+            self.logHandler?.debug(message: "Received presence update from channel", error: nil)
             self.handleARTPresenceMessage(message, for: trackable)
         }
     }
@@ -290,7 +290,7 @@ public class DefaultAbly: AblyCommon {
             }
             
             let receivedConnectionState = stateChange.current.toConnectionState()
-            self.logHandler?.debug(message: "\(String(describing: Self.self)): Channel state for trackable \(trackable.id) changed. New state: \(receivedConnectionState.description)", error: nil)
+            self.logHandler?.debug(message: "Channel state for trackable \(trackable.id) changed. New state: \(receivedConnectionState.description)", error: nil)
             self.publisherDelegate?.ablyPublisher(self, didChangeChannelConnectionState: receivedConnectionState, forTrackable: trackable)
         }
     }
@@ -313,11 +313,11 @@ public class DefaultAbly: AblyCommon {
         client.connection.on {[weak self] stateChange in
             switch stateChange.current {
             case .closed:
-                self?.logHandler?.info(message: "\(String(describing: Self.self)): Ably connection closed successfully.", error: nil)
+                self?.logHandler?.info(message: "Ably connection closed successfully.", error: nil)
                 completion(.success)
             case .failed:
                 let errorInfo = stateChange.reason?.toErrorInformation() ?? ErrorInformation(type: .publisherError(errorMessage: "Cannot close connection"))
-                self?.logHandler?.error(message: "\(String(describing: Self.self)): Error while closing connection", error: errorInfo)
+                self?.logHandler?.error(message: "Error while closing connection", error: errorInfo)
                 completion(.failure(errorInfo))
             default:
                 return
@@ -335,7 +335,7 @@ extension DefaultAbly: AblySubscriber {
         }
         
         channel.subscribe(EventName.raw.rawValue) { [weak self] message in
-            self?.logHandler?.debug(message: "\(String(describing: Self.self)): Received raw location message from channel", error: nil)
+            self?.logHandler?.debug(message: "Received raw location message from channel", error: nil)
             self?.handleLocationUpdateResponse(forEvent: .raw, messageData: message.data)
         }
     }
@@ -346,7 +346,7 @@ extension DefaultAbly: AblySubscriber {
         }
         
         channel.subscribe(EventName.enhanced.rawValue) { [weak self] message in
-            self?.logHandler?.debug(message: "\(String(describing: Self.self)): Received enhanced location message from channel", error: nil)
+            self?.logHandler?.debug(message: "Received enhanced location message from channel", error: nil)
             self?.handleLocationUpdateResponse(forEvent: .enhanced, messageData: message.data)
         }
     }
@@ -354,7 +354,7 @@ extension DefaultAbly: AblySubscriber {
     private func handleLocationUpdateResponse(forEvent event: EventName, messageData: Any?) {
         guard let json = messageData as? String else {
             let errorInformation = ErrorInformation(code: ErrorCode.invalidMessage.rawValue, statusCode: 400, message: "Received a non-string message for \(event.rawValue) event: \(String(describing: messageData))", cause: nil, href: nil)
-            logHandler?.error(message: "\(String(describing: Self.self)): Received a non-string message for \(event.rawValue) event: \(String(describing: messageData))", error: errorInformation)
+            logHandler?.error(message: "Received a non-string message for \(event.rawValue) event: \(String(describing: messageData))", error: errorInformation)
             subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
             
             return
@@ -376,11 +376,11 @@ extension DefaultAbly: AblySubscriber {
         } catch let error {
             guard let errorInformation = error as? ErrorInformation else {
                 let errorInformation = ErrorInformation(code: ErrorCode.invalidMessage.rawValue, statusCode: 400, message: "Received a malformed message for \(event.rawValue) event", cause: error, href: nil)
-                logHandler?.error(message: "\(String(describing: Self.self)): Received a malformed message for \(event.rawValue) event", error: errorInformation)
+                logHandler?.error(message: "Received a malformed message for \(event.rawValue) event", error: errorInformation)
                 subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
                 return
             }
-            logHandler?.error(message: "\(String(describing: Self.self)): Cannot parse message data for \(event.rawValue) event:", error: errorInformation)
+            logHandler?.error(message: "Cannot parse message data for \(event.rawValue) event:", error: errorInformation)
             subscriberDelegate?.ablySubscriber(self, didFailWithError: errorInformation)
             
             return
@@ -405,7 +405,7 @@ extension DefaultAbly: AblyPublisher {
         
         guard let channel = channels[trackable.id] else {
             let errorInformation = ErrorInformation(type: .publisherError(errorMessage: "Attempt to send location while not tracked channel"))
-            logHandler?.error(message: "\(String(describing: Self.self)): Attempting to send a location while channel is not tracked", error: errorInformation)
+            logHandler?.error(message: "Attempting to send a location while channel is not tracked", error: errorInformation)
             completion?(.failure(errorInformation))
             
             return
@@ -418,7 +418,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            logHandler?.error(message: "\(String(describing: Self.self)): Cannot create location update message. Underlying error", error: error)
+            logHandler?.error(message: "Cannot create location update message. Underlying error", error: error)
             publisherDelegate?.ablyPublisher(self, didFailWithError: errorInformation)
             
             return
@@ -430,7 +430,7 @@ extension DefaultAbly: AblyPublisher {
             }
             
             if let error = error {
-                self.logHandler?.error(message: "\(String(describing: Self.self)): Cannot publish a message to channel [trackable id: \(trackable.id)]", error: error)
+                self.logHandler?.error(message: "Cannot publish a message to channel [trackable id: \(trackable.id)]", error: error)
                 self.publisherDelegate?.ablyPublisher(self, didFailWithError: error.toErrorInformation())
                 
                 return
@@ -462,7 +462,7 @@ extension DefaultAbly: AblyPublisher {
                 else { return }
                 
                 if let error = error {
-                    self.logHandler?.error(message: "\(String(describing: Self.self)): Cannot publish a message to channel [trackable id: \(trackable.id)]", error: error)
+                    self.logHandler?.error(message: "Cannot publish a message to channel [trackable id: \(trackable.id)]", error: error)
                     self.publisherDelegate?.ablyPublisher(self, didFailWithError: error.toErrorInformation())
                 } else {
                     completion?(.success)
@@ -472,7 +472,7 @@ extension DefaultAbly: AblyPublisher {
             let errorInformation = ErrorInformation(
                 type: .publisherError(errorMessage: "Cannot create location update message. Underlying error: \(error)")
             )
-            self.logHandler?.error(message: "\(String(describing: Self.self)): Cannot create location update message.", error: errorInformation)
+            self.logHandler?.error(message: "Cannot create location update message.", error: errorInformation)
             publisherDelegate?.ablyPublisher(self, didFailWithError: errorInformation)
         }
     }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -10,27 +10,28 @@ public class DefaultAbly: AblyCommon {
      //log handler used to capture internal events from the Ably-Cocoa, and pass them to LogHandler via `logCallback`
     private let internalARTLogHandler: InternalARTLogHandler = InternalARTLogHandler()
     
-    private let logHandler: LogHandler?
+    private let logHandler: HierarchicalLogHandler?
     private let client: AblySDKRealtime
     private let connectionConfiguration: ConnectionConfiguration
     let mode: AblyMode
     
     private var channels: [String: AblySDKRealtimeChannel] = [:]
 
-    public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, mode: AblyMode, logHandler: LogHandler?) {
-        self.logHandler = logHandler
+    public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, mode: AblyMode, logHandler: HierarchicalLogHandler?) {
+        self.logHandler = logHandler?.addingSubsystem(Self.self)
+        let ablySDKSubsystemLogHandler = self.logHandler?.addingSubsystem(.named("ablySDK"))
         internalARTLogHandler.logCallback = { (message, level, error) in
             switch level {
             case .verbose:
-                logHandler?.verbose(message: message, error: error)
+                ablySDKSubsystemLogHandler?.verbose(message: message, error: error)
             case .info:
-                logHandler?.info(message: message, error: error)
+                ablySDKSubsystemLogHandler?.info(message: message, error: error)
             case .debug:
-                logHandler?.debug(message: message, error: error)
+                ablySDKSubsystemLogHandler?.debug(message: message, error: error)
             case .warn:
-                logHandler?.warn(message: message, error: error)
+                ablySDKSubsystemLogHandler?.warn(message: message, error: error)
             case .error:
-                logHandler?.error(message: message, error: error)
+                ablySDKSubsystemLogHandler?.error(message: message, error: error)
             }
         }
         self.client = factory.create(withConfiguration: configuration, logHandler: internalARTLogHandler)

--- a/Sources/AblyAssetTrackingInternal/Logging/DefaultHierarchicalLogHandler.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/DefaultHierarchicalLogHandler.swift
@@ -1,0 +1,34 @@
+import AblyAssetTrackingCore
+
+/// Provides an implementation of ``HierarchicalLogHandler`` by wrapping another instance of ``LogHandler``. It will insert a string such as "[asset-tracking.publisher.DefaultPublisher]" into the log messages, representing its list of subsystems.
+public struct DefaultHierarchicalLogHandler: HierarchicalLogHandler {
+    private var logHandler: LogHandler
+    private var subsystemNames: [String] // Lowest granularity first
+    
+    /// Creates an instance of ``DefaultHierarchicalLogHandler`` that writes messages to a given ``LogHandler``. The lowest-granularity subsystem of the returned log handler will always be "assetTracking".
+    /// - Parameters:
+    ///   - logHandler: A log handler to write messages to. If this is nil, the initializer will return nil.
+    ///   - subsystem: A subsystem to add to the list
+    public init?(logHandler: LogHandler?, subsystem: Subsystem? = nil) {
+        guard let logHandler = logHandler else {
+            return nil
+        }
+        self.logHandler = logHandler
+        
+        self.subsystemNames = ["assetTracking"]
+        if let subsystem = subsystem {
+            self.subsystemNames.append(subsystem.name)
+        }
+    }
+    
+    public func logMessage(level: LogLevel, message: String, error: Error?) {
+        let newMessage = "[\(subsystemNames.joined(separator: "."))] \(message)"
+        logHandler.logMessage(level: level, message: newMessage, error: error)
+    }
+    
+    public func addingSubsystem(_ subsystem: Subsystem) -> HierarchicalLogHandler {
+        var newHandler = self
+        newHandler.subsystemNames.append(subsystem.name)
+        return newHandler
+    }
+}

--- a/Sources/AblyAssetTrackingInternal/Logging/HierarchicalLogHandler.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/HierarchicalLogHandler.swift
@@ -1,0 +1,36 @@
+import AblyAssetTrackingCore
+
+/// A description of some component of the SDK which wishes to identify itself in a log message.
+public enum Subsystem {
+    /// An arbitrary component with a name.
+    case named(String)
+    /// A component that is a Swift type.
+    case typed(Any.Type)
+    
+    /// The text that will be used to identify this component in a log message.
+    var name: String {
+        switch self {
+        case .named(let name):
+            return name
+        case .typed(let type):
+            return String(describing: type)
+        }
+    }
+}
+
+/// A log handler that stores a hierarchy of subsystems of increasing granularity, for example ["asset-tracking", "publisher", "DefaultPublisher"]. It is expected that it will use this information to output some sort of information about these subsystems in the log messages that it outputs, for example by adding a string "[asset-tracking.publisher.DefaultPublisher]".
+public protocol HierarchicalLogHandler: LogHandler {
+    /// Adds another subsystem to the log handler’s list.
+    /// - Parameter subsystem: The subsystem to add. This will be added at a higher level of granularity then the subsystems currently in the log handler’s list.
+    /// - Returns: A new log handler.
+    func addingSubsystem(_ subsystem: Subsystem) -> HierarchicalLogHandler
+}
+
+extension HierarchicalLogHandler {
+    /// A convenience method for adding a Swift type to the log handler’s list.
+    /// - Parameter type: The Swift type to add, for example `DefaultPublisher.self`.
+    /// - Returns: A new log handler.
+    public func addingSubsystem(_ type: Any.Type) -> HierarchicalLogHandler {
+        return addingSubsystem(.typed(type))
+    }
+}

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -156,7 +156,7 @@ class DefaultPublisher: Publisher {
 // MARK: Threading events handling
 extension DefaultPublisher {
     private func enqueue(event: Event) {
-        logHandler?.verbose(message: "\(String(describing: Self.self)): received event: \(event)", error: nil)
+        logHandler?.verbose(message: "Received event: \(event)", error: nil)
         performOnWorkingQueue { [weak self] in
             switch event {
             case .trackTrackable(let event): self?.performTrackTrackableEvent(event)
@@ -190,7 +190,7 @@ extension DefaultPublisher {
     }
 
     private func sendDelegateEvent(_ event: DelegateEvent) {
-        logHandler?.verbose(message: "\(String(describing: Self.self)): received delegate event: \(event)", error: nil)
+        logHandler?.verbose(message: "Received delegate event: \(event)", error: nil)
 
         Self.performOnMainThread { [weak self] in
             guard let self = self
@@ -239,7 +239,7 @@ extension DefaultPublisher {
                     case .success(let route):
                         self?.enqueue(event: .setDestinationSuccess(.init(route: route)))
                     case .failure(let error):
-                        self?.logHandler?.error(message: "\(String(describing: Self.self)): can't fetch route.", error: error)
+                        self?.logHandler?.error(message: "Can't fetch route.", error: error)
                         event.completion.handleError(error)
                     }
                 }
@@ -292,7 +292,7 @@ extension DefaultPublisher {
                 self.enqueue(event: .setDestinationSuccess(.init(route: route)))
                 event.completion.handleSuccess()
             case .failure(let error):
-                self.logHandler?.error(message: "\(String(describing: Self.self)): can't change RoutingProfile", error: error)
+                self.logHandler?.error(message: "Can't change RoutingProfile", error: error)
                 event.completion.handleError(error)
             }
         }
@@ -379,7 +379,7 @@ extension DefaultPublisher {
             
             switch result {
             case .failure(let error):
-                self.logHandler?.error(message: "\(Self.self): Failed to stop recording location", error: error)
+                self.logHandler?.error(message: "Failed to stop recording location", error: error)
             case .success(let locationRecordingResult):
                 if let locationRecordingResult = locationRecordingResult {
                     self.sendDelegateEvent(.finishedRecordingLocationHistoryData(.init(locationHistoryData: locationRecordingResult.locationHistoryData)))
@@ -498,7 +498,7 @@ extension DefaultPublisher {
     // MARK: Location change
     private func performEnhancedLocationChanged(_ event: Event.EnhancedLocationChangedEvent) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "\(String(describing: Self.self)): cannot perform EnhancedLocationChangedEvent. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform EnhancedLocationChangedEvent. Publisher is either stopped or stopping.")))
             return
         }
 
@@ -591,7 +591,7 @@ extension DefaultPublisher {
     
     private func performRawLocationChanged(_ event: Event.RawLocationChangedEvent) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "\(String(describing: Self.self)): cannot perform RawLocationChanged. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform RawLocationChanged. Publisher is either stopped or stopping.")))
             return
         }
         
@@ -706,7 +706,7 @@ extension DefaultPublisher {
     // MARK: ResolutionPolicy
     private func performRefreshResolutionPolicyEvent(_ event: Event.RefreshResolutionPolicyEvent) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "\(String(describing: Self.self)): cannot perform RefreshResolutionPolicyEvent. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform RefreshResolutionPolicyEvent. Publisher is either stopped or stopping.")))
             return
         }
 
@@ -734,7 +734,7 @@ extension DefaultPublisher {
 
     private func changeLocationEngineResolution(resolution: Resolution) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "\(String(describing: Self.self)): cannot perform ChangeLocationEngineResolution. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform ChangeLocationEngineResolution. Publisher is either stopped or stopping.")))
             return
         }
         
@@ -769,7 +769,7 @@ extension DefaultPublisher {
     // MARK: Subscribers handling
     private func performPresenceUpdateEvent(_ event: Event.PresenceUpdateEvent) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "\(String(describing: Self.self)): cannot perform PresenceUpdateEvent. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform PresenceUpdateEvent. Publisher is either stopped or stopping.")))
             return
         }
 
@@ -874,17 +874,17 @@ extension DefaultPublisher {
 // MARK: LocationServiceDelegate
 extension DefaultPublisher: LocationServiceDelegate {
     func locationService(sender: LocationService, didFailWithError error: ErrorInformation) {
-        logHandler?.error(message: "\(String(describing: Self.self)): locationService.didFailWithError.", error: error)
+        logHandler?.error(message: "locationService.didFailWithError.", error: error)
         sendDelegateEvent(.error(.init(error: error)))
     }
 
     func locationService(sender: LocationService, didUpdateRawLocationUpdate locationUpdate: RawLocationUpdate) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): locationService.didUpdateRawLocation.", error: nil)
+        logHandler?.debug(message: "locationService.didUpdateRawLocation.", error: nil)
         enqueue(event: .rawLocationChanged(.init(locationUpdate: locationUpdate)))
     }
     
     func locationService(sender: LocationService, didUpdateEnhancedLocationUpdate locationUpdate: EnhancedLocationUpdate) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): locationService.didUpdateEnhancedLocation.", error: nil)
+        logHandler?.debug(message: "locationService.didUpdateEnhancedLocation.", error: nil)
         enqueue(event: .enhancedLocationChanged(.init(locationUpdate: locationUpdate)))
         sendDelegateEvent(.enhancedLocationChanged(.init(locationUpdate: locationUpdate)))
     }
@@ -893,17 +893,17 @@ extension DefaultPublisher: LocationServiceDelegate {
 // MARK: AblyPublisherDelegate
 extension DefaultPublisher: AblyPublisherDelegate {
     func ablyPublisher(_ sender: AblyPublisher, didChangeChannelConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablyPublisher.didChangeChannelConnectionState. State: \(state) for trackable: \(trackable.id)", error: nil)
+        logHandler?.debug(message: "ablyPublisher.didChangeChannelConnectionState. State: \(state) for trackable: \(trackable.id)", error: nil)
         enqueue(event: .ablyChannelConnectionStateChanged(.init(trackable: trackable, connectionState: state)))
     }
 
     func ablyPublisher(_ sender: AblyPublisher, didFailWithError error: ErrorInformation) {
-        logHandler?.error(message: "\(String(describing: Self.self)): ablyPublisher.didFailWithError.", error: error)
+        logHandler?.error(message: "ablyPublisher.didFailWithError.", error: error)
         sendDelegateEvent(.error(.init(error: error)))
     }
 
     func ablyPublisher(_ sender: AblyPublisher, didChangeConnectionState state: ConnectionState) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablyPublisher.didChangeConnectionState. State: \(state.description)", error: nil)
+        logHandler?.debug(message: "ablyPublisher.didChangeConnectionState. State: \(state.description)", error: nil)
         enqueue(event: .ablyClientConnectionStateChanged(.init(connectionState: state)))
     }
 
@@ -913,7 +913,7 @@ extension DefaultPublisher: AblyPublisherDelegate {
                           presenceData: PresenceData,
                           clientId: String) {
 
-        logHandler?.debug(message: "\(String(describing: Self.self)): publisherService.didReceivePresenceUpdate. Presence: \(presence), Trackable: \(trackable)", error: nil)
+        logHandler?.debug(message: "publisherService.didReceivePresenceUpdate. Presence: \(presence), Trackable: \(trackable)", error: nil)
         enqueue(event: .presenceUpdate(.init(trackable: trackable, presence: presence, presenceData: presenceData, clientId: clientId)))
     }
 }

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -56,7 +56,7 @@ class DefaultPublisher: Publisher {
     private var lastRawTimestamps: [Trackable: Double]
     private var route: Route?
     
-    private var logHandler: LogHandler?
+    private var logHandler: HierarchicalLogHandler?
 
     private var receivedAblyClientConnectionState: ConnectionState = .offline
     private var receivedAblyChannelsConnectionStates: [Trackable: ConnectionState] = [:]
@@ -78,7 +78,7 @@ class DefaultPublisher: Publisher {
          areRawLocationsEnabled: Bool = false,
          isSendResolutionEnabled: Bool = true,
          constantLocationEngineResolution: Resolution? = nil,
-         logHandler: LogHandler?
+         logHandler: HierarchicalLogHandler?
     ) {
         
         self.connectionConfiguration = connectionConfiguration
@@ -90,7 +90,7 @@ class DefaultPublisher: Publisher {
         self.routeProvider = routeProvider
         self.enhancedLocationState = enhancedLocationState
         self.rawLocationState = rawLocationState
-        self.logHandler = logHandler
+        self.logHandler = logHandler?.addingSubsystem(Self.self)
 
         self.batteryLevelProvider = DefaultBatteryLevelProvider()
         

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -57,11 +57,14 @@ class DefaultPublisherBuilder: PublisherBuilder {
             throw ErrorInformation(type: .incompleteConfiguration(missingProperty: "ResolutionPolicyFactory", forBuilderOption: "resolutionPolicyFactory"))
         }
         
+        let hierarchicalLogHandler = DefaultHierarchicalLogHandler(logHandler: logHandler,
+                                                                   subsystem: .named("publisher"))
+        
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
             mode: .publish,
-            logHandler: logHandler
+            logHandler: hierarchicalLogHandler
         )
         
         let publisher =  DefaultPublisher(connectionConfiguration: connection,
@@ -69,12 +72,12 @@ class DefaultPublisherBuilder: PublisherBuilder {
                                           routingProfile: routingProfile,
                                           resolutionPolicyFactory: resolutionPolicyFactory,
                                           ablyPublisher: defaultAbly,
-                                          locationService: DefaultLocationService(mapboxConfiguration: mapboxConfiguration, historyLocation: locationSource?.locations, logHandler: logHandler, vehicleProfile: vehicleProfile),
+                                          locationService: DefaultLocationService(mapboxConfiguration: mapboxConfiguration, historyLocation: locationSource?.locations, logHandler: hierarchicalLogHandler, vehicleProfile: vehicleProfile),
                                           routeProvider: DefaultRouteProvider(mapboxConfiguration: mapboxConfiguration),
                                           areRawLocationsEnabled: areRawLocationsEnabled,
                                           isSendResolutionEnabled: isSendResolutionEnabled,
                                           constantLocationEngineResolution: constantLocationEngineResolution,
-                                          logHandler: logHandler)
+                                          logHandler: hierarchicalLogHandler)
         publisher.delegate = delegate
         return publisher
     }

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
@@ -45,7 +45,7 @@ class DefaultLocationService: LocationService {
         do {
             try LocationHistoryTemporaryStorageConfiguration.configureMapboxHistoryStorageLocation()
         } catch {
-            logHandler?.error(message: "\(Self.self): Failed to configure Mapbox history storage location", error: error)
+            self.logHandler?.error(message: "Failed to configure Mapbox history storage location", error: error)
         }
 
         if let historyLocation = historyLocation {
@@ -113,14 +113,14 @@ class DefaultLocationService: LocationService {
                 
                 guard let historyFileURL = historyFileURL else {
                     let error = ErrorInformation(type: .commonError(errorMessage: "PassiveLocationManager.stopRecordingHistory did not return a file URL"))
-                    self.logHandler?.info(message: "\(Self.self): PassiveLocationManager.stopRecordingHistory returned a nil historyFileURL – not treating as an error since it might be that we never started recording history", error: error)
+                    self.logHandler?.info(message: "PassiveLocationManager.stopRecordingHistory returned a nil historyFileURL – not treating as an error since it might be that we never started recording history", error: error)
                     completion(.success(nil))
                     return
                 }
                 
                 guard let reader = HistoryReader(fileUrl: historyFileURL) else {
                     let error = ErrorInformation(type: .commonError(errorMessage: "HistoryReader(fileUrl:) returned nil"))
-                    self.logHandler?.error(message: "\(Self.self): Failed to complete recording of history", error: error)
+                    self.logHandler?.error(message: "Failed to complete recording of history", error: error)
                     completion(.failure(.init(type: .commonError(errorMessage: "Failed to create HistoryReader"))))
                     return
                 }
@@ -138,7 +138,7 @@ class DefaultLocationService: LocationService {
                     
                     locationHistoryData = LocationHistoryData(events: events)
                 } catch {
-                    self.logHandler?.error(message: "\(Self.self): Failed to map location history reader events to GeoJSONMessage", error: error)
+                    self.logHandler?.error(message: "Failed to map location history reader events to GeoJSONMessage", error: error)
                     completion(.failure(.init(error: error)))
                     return
                 }
@@ -161,7 +161,7 @@ class DefaultLocationService: LocationService {
 
 extension DefaultLocationService: PassiveLocationManagerDelegate {
     func passiveLocationManagerDidChangeAuthorization(_ manager: PassiveLocationManager) {
-        logHandler?.debug(message: "\(String(describing: Self.self)), passiveLocationManager.passiveLocationManagerDidChangeAuthorization", error: nil)
+        logHandler?.debug(message: "passiveLocationManager.passiveLocationManagerDidChangeAuthorization", error: nil)
     }
     
     func passiveLocationManager(_ manager: PassiveLocationManager, didUpdateLocation location: CLLocation, rawLocation: CLLocation) {
@@ -170,11 +170,11 @@ extension DefaultLocationService: PassiveLocationManagerDelegate {
     }
     
     func passiveLocationManager(_ manager: PassiveLocationManager, didUpdateHeading newHeading: CLHeading) {
-        logHandler?.debug(message: "\(String(describing: Self.self)), passiveLocationManager.didUpdateHeading", error: nil)
+        logHandler?.debug(message: "passiveLocationManager.didUpdateHeading", error: nil)
     }
     
     func passiveLocationManager(_ manager: PassiveLocationManager, didFailWithError error: Error) {
-        logHandler?.error(message: "\(String(describing: Self.self)), passiveLocationManager.didFailWithError", error: error)
+        logHandler?.error(message: "passiveLocationManager.didFailWithError", error: error)
         let errorInformation = ErrorInformation(type: .publisherError(errorMessage: error.localizedDescription))
         delegate?.locationService(sender: self, didFailWithError: errorInformation)
     }

--- a/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
+++ b/Sources/AblyAssetTrackingPublisher/Services/DefaultLocationService.swift
@@ -2,19 +2,21 @@ import CoreLocation
 import MapboxCoreNavigation
 import MapboxDirections
 import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
 
 class DefaultLocationService: LocationService {
     private let locationManager: PassiveLocationManager
     private let replayLocationManager: ReplayLocationManager?
-    private let logHandler: LogHandler?
+    private let logHandler: HierarchicalLogHandler?
     private let workQueue = DispatchQueue(label: "com.ably.AssetTracking.DefaultLocationService.workQueue")
 
     weak var delegate: LocationServiceDelegate?
 
     init(mapboxConfiguration: MapboxConfiguration,
          historyLocation: [CLLocation]?,
-         logHandler: LogHandler?,
+         logHandler: HierarchicalLogHandler?,
          vehicleProfile: VehicleProfile) {
+        self.logHandler = logHandler?.addingSubsystem(Self.self)
 
         let directions = Directions(credentials: mapboxConfiguration.getCredentials())
 
@@ -51,7 +53,6 @@ class DefaultLocationService: LocationService {
         } else {
             replayLocationManager = nil
         }
-        self.logHandler = logHandler
         //set location manager with profile identifier only if .Bicycle is provided by clients
         if vehicleProfile == .bicycle {
             self.locationManager = PassiveLocationManager(systemLocationManager: replayLocationManager ,datasetProfileIdentifier: .cycling)

--- a/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
+++ b/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
@@ -26,10 +26,10 @@ public final class TemporaryFile {
         Self.cleanupQueue.async { [fileURL, logHandler, didDeleteCallback] in
             do {
                 try FileManager.default.removeItem(at: fileURL)
-                logHandler?.debug(message: "\(Self.self): Removed file at \(fileURL)", error: nil)
+                logHandler?.debug(message: "Removed file at \(fileURL)", error: nil)
                 didDeleteCallback?()
             } catch {
-                logHandler?.error(message: "\(Self.self): Failed to remove file at \(fileURL)", error: error)
+                logHandler?.error(message: "Failed to remove file at \(fileURL)", error: error)
             }
         }
     }

--- a/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
+++ b/Sources/AblyAssetTrackingPublisher/Storage/TemporaryFile.swift
@@ -1,17 +1,18 @@
 import Foundation
 import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
 
 /// A reference to a temporary file which will be deleted once there are no remaining strong references to this object.
 public final class TemporaryFile {
     public let fileURL: URL
-    private let logHandler: LogHandler?
+    private let logHandler: HierarchicalLogHandler?
     // For testing this class.
     private let didDeleteCallback: (() -> Void)?
     private static let cleanupQueue = DispatchQueue(label: "com.ably.AssetTracking.TemporaryFile.cleanupQueue", qos: .background)
     
-    init(fileURL: URL, logHandler: LogHandler?, didDeleteCallback: (() -> Void)? = nil) {
+    init(fileURL: URL, logHandler: HierarchicalLogHandler?, didDeleteCallback: (() -> Void)? = nil) {
         self.fileURL = fileURL
-        self.logHandler = logHandler
+        self.logHandler = logHandler?.addingSubsystem(Self.self)
         self.didDeleteCallback = didDeleteCallback
     }
     

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -107,7 +107,7 @@ class DefaultSubscriber: Subscriber {
 
 extension DefaultSubscriber {
     private func enqueue(event: Event) {
-        logHandler?.verbose(message: "\(String(describing: Self.self)): enqueuing event: \(event)", error: nil)
+        logHandler?.verbose(message: "Enqueuing event: \(event)", error: nil)
         performOnWorkingThread { [weak self] in
             switch event {
             case .start(let event): self?.performStart(event)
@@ -131,7 +131,7 @@ extension DefaultSubscriber {
     }
 
     private func callback(event: DelegateEvent) {
-        logHandler?.verbose(message: "\(String(describing: Self.self)): received delegate event: \(event)", error: nil)
+        logHandler?.verbose(message: "Received delegate event: \(event)", error: nil)
         performOnMainThread { [weak self] in
             guard let self = self,
                   let delegate = self.delegate
@@ -222,7 +222,7 @@ extension DefaultSubscriber {
     
     private func handleConnectionStateChange() {
         if currentTrackableConnectionState == .failed {
-            logHandler?.debug(message: "\(String(describing: Self.self)): Ignoring state change since state is already .failed", error: nil)
+            logHandler?.debug(message: "Ignoring state change since state is already .failed", error: nil)
             return
         }
         
@@ -276,13 +276,13 @@ extension DefaultSubscriber {
         callback(event: .delegateError(.init(error: event.error)))
         
         if event.error.code == ErrorCode.invalidMessage.rawValue {
-            logHandler?.error(message: "\(String(describing: Self.self)): invalidMessage error received, emitting failed connection status", error: event.error)
+            logHandler?.error(message: "invalidMessage error received, emitting failed connection status", error: event.error)
             currentTrackableConnectionState = .failed
             callback(event: .delegateConnectionStatusChanged(.init(status: .failed)))
 
             ablySubscriber.disconnect(trackableId: trackableId, presenceData: nil) { [weak self, trackableId] error in
                 if case .failure(let error) = error {
-                    self?.logHandler?.error(message: "\(String(describing: Self.self)): Failed to disconnect trackable (\(trackableId)) after receiving invalid message.", error: error)
+                    self?.logHandler?.error(message: "Failed to disconnect trackable (\(trackableId)) after receiving invalid message.", error: error)
                 }
             }
         }
@@ -300,37 +300,37 @@ extension DefaultSubscriber {
 
 extension DefaultSubscriber: AblySubscriberDelegate {
     func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: Presence) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didReceivePresenceUpdate. Presence: \(presence)", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didReceivePresenceUpdate. Presence: \(presence)", error: nil)
         enqueue(event: .presenceUpdate(.init(presence: presence)))
     }
     
     func ablySubscriber(_ sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didChangeClientConnectionState. Status: \(state)", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didChangeClientConnectionState. Status: \(state)", error: nil)
         enqueue(event: .ablyClientConnectionStateChanged(.init(connectionState: state)))
     }
     
     func ablySubscriber(_ sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didChangeChannelConnectionState. Status: \(state)", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didChangeChannelConnectionState. Status: \(state)", error: nil)
             enqueue(event: .ablyChannelConnectionStateChanged(.init(connectionState: state)))
     }
 
     func ablySubscriber(_ sender: AblySubscriber, didFailWithError error: ErrorInformation) {
-        logHandler?.error(message: "\(String(describing: Self.self)): ablySubscriber.didFailWithError", error: error)
+        logHandler?.error(message: "ablySubscriber.didFailWithError", error: error)
         enqueue(event: .ablyError(.init(error: error)))
     }
 
     func ablySubscriber(_ sender: AblySubscriber, didReceiveRawLocation location: LocationUpdate) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didReceiveRawLocation", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didReceiveRawLocation", error: nil)
         callback(event: .delegateRawLocationReceived(.init(locationUpdate: location)))
     }
     
     func ablySubscriber(_ sender: AblySubscriber, didReceiveEnhancedLocation location: LocationUpdate) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didReceiveEnhancedLocation", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didReceiveEnhancedLocation", error: nil)
         callback(event: .delegateEnhancedLocationReceived(.init(locationUpdate: location)))
     }
     
     func ablySubscriber(_ sender: AblySubscriber, didReceiveResolution resolution: Resolution) {
-        logHandler?.debug(message: "\(String(describing: Self.self)): ablySubscriber.didReceiveResolution", error: nil)
+        logHandler?.debug(message: "ablySubscriber.didReceiveResolution", error: nil)
         callback(event: .delegateResolutionReceived(.init(resolution: resolution)))
         callback(event: .delegateDesiredIntervalReceived(.init(desiredInterval: resolution.desiredInterval)))
     }

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -36,13 +36,13 @@ class DefaultSubscriber: Subscriber {
         ablySubscriber: AblySubscriber,
         trackableId: String,
         resolution: Resolution?,
-        logHandler: LogHandler?) {
+        logHandler: HierarchicalLogHandler?) {
             
         self.workingQueue = DispatchQueue(label: "com.ably.Subscriber.DefaultSubscriber", qos: .default)
         self.ablySubscriber = ablySubscriber
         self.trackableId = trackableId
         self.presenceData = PresenceData(type: .subscriber, resolution: resolution)
-        self.logHandler = logHandler
+        self.logHandler = logHandler?.addingSubsystem(Self.self)
         
         self.ablySubscriber.subscriberDelegate = self
         

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
@@ -37,18 +37,21 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
             completion(.failure(error))
             return nil
         }
+        
+        let hierarchicalLogHandler = DefaultHierarchicalLogHandler(logHandler: logHandler,
+                                                                   subsystem: .named("subscriber"))
 
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
             mode: .subscribe,
-            logHandler: logHandler
+            logHandler: hierarchicalLogHandler
         )
         let subscriber = DefaultSubscriber(
             ablySubscriber: defaultAbly,
             trackableId: trackingId,
             resolution: resolution,
-            logHandler: logHandler
+            logHandler: hierarchicalLogHandler
         )
         subscriber.delegate = delegate
         subscriber.start(completion: completion)

--- a/Sources/AblyAssetTrackingUI/LocationAnimator/DefaultLocationAnimator.swift
+++ b/Sources/AblyAssetTrackingUI/LocationAnimator/DefaultLocationAnimator.swift
@@ -32,7 +32,7 @@ public class DefaultLocationAnimator: NSObject, LocationAnimator {
     private var subscribeForPositionUpdatesClosure: ((Position) -> Void)?
     private var subscribeForCameraPositionUpdatesClosure: ((Position) -> Void)?
         
-    private let logHandler: LogHandler?
+    private let logHandler: HierarchicalLogHandler?
     
     private var nextLocationUpdatePrediction: DefaultLocationAnimatorCalculator.Input.Context.NextLocationUpdatePrediction?
     private var state = DefaultLocationAnimatorCalculator.Input.State.initial
@@ -42,7 +42,7 @@ public class DefaultLocationAnimator: NSObject, LocationAnimator {
     }
     
     public init(logHandler: LogHandler? = nil) {
-        self.logHandler = logHandler
+        self.logHandler = DefaultHierarchicalLogHandler(logHandler: logHandler, subsystem: .typed(Self.self))
         super.init()
         
         displayLinkTarget.locationAnimator = self

--- a/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
+++ b/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
@@ -6,7 +6,7 @@ import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingInternalTesting
 
 class DefaultAblyTests: XCTestCase {
-    let logger = LogHandlerMock()
+    let logger = MockHierarchicalLogHandler()
 
     func test_connect_whenNotConfiguredToUseToken_whenPresenceEnterFails_withAnErrorRelatedToCapabilities_itFails() {
         let presence = AblySDKRealtimePresenceMock()

--- a/Tests/InternalTests/DefaultHierarchicalLogHandlerTests.swift
+++ b/Tests/InternalTests/DefaultHierarchicalLogHandlerTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import AblyAssetTrackingInternal
+import AblyAssetTrackingCoreTesting
+
+class DefaultHierarchicalLogHandlerTests: XCTestCase {
+    func test_init_withNilLogHandler_returnsNil() {
+        XCTAssertNil(DefaultHierarchicalLogHandler(logHandler: nil))
+    }
+    
+    func test_addSubsystem_causesLoggedMessagesToIncludeSubsystemName() throws {
+        let underlyingLogHandler = LogHandlerMock()
+        let logHandler = try XCTUnwrap(DefaultHierarchicalLogHandler(logHandler: underlyingLogHandler))
+            .addingSubsystem(.named("myComponent"))
+
+        logHandler.logMessage(level: .info, message: "Here is a message", error: nil)
+        
+        let receivedArguments = try XCTUnwrap(underlyingLogHandler.logMessageLevelMessageErrorReceivedArguments)
+        XCTAssertEqual(receivedArguments.level, .info)
+        XCTAssertEqual(receivedArguments.message, "[assetTracking.myComponent] Here is a message")
+        XCTAssertNil(receivedArguments.error)
+    }
+}

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -21,7 +21,7 @@ class DefaultPublisherTests: XCTestCase {
     var delegate: MockPublisherDelegate!
     var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
     
-    let logger = LogHandlerMock()
+    let logger = MockHierarchicalLogHandler()
     let waitAsync = WaitAsync()
     
     override func setUpWithError() throws {

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -21,7 +21,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     var waitAsync: WaitAsync!
     var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
     var rawLocationState: TrackableState<RawLocationUpdate>!
-    var logger: LogHandlerMock!
+    var logger: MockHierarchicalLogHandler!
     
     override func setUpWithError() throws {
         locationService = MockLocationService()
@@ -34,7 +34,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         waitAsync = WaitAsync()
         enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
         rawLocationState = TrackableState<RawLocationUpdate>()
-        logger = LogHandlerMock()
+        logger = MockHierarchicalLogHandler()
         
         trackable = Trackable(
             id: "TrackableId",

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -96,7 +96,7 @@ class PublisherHelper {
         locationService: LocationService = MockLocationService(),
         routeProvider: RouteProvider = MockRouteProvider(),
         enhancedLocationState: TrackableState<EnhancedLocationUpdate> = TrackableState<EnhancedLocationUpdate>(),
-        logHandler: LogHandlerMock = LogHandlerMock()
+        logHandler: MockHierarchicalLogHandler = MockHierarchicalLogHandler()
     ) -> DefaultPublisher {
         
         DefaultPublisher(

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -12,7 +12,7 @@ class DefaultSubscriberTests: XCTestCase {
     private var trackableId: String!
     
     private let configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
-    private let logger = LogHandlerMock()
+    private let logger = MockHierarchicalLogHandler()
     
     override func setUpWithError() throws {
         trackableId = "Trackable-\(UUID().uuidString)"

--- a/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/MockHierarchicalLogHandler.swift
+++ b/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/MockHierarchicalLogHandler.swift
@@ -1,0 +1,12 @@
+import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
+
+public class MockHierarchicalLogHandler: HierarchicalLogHandler {
+    public init() {}
+    
+    public func addingSubsystem(_ subsystem: Subsystem) -> AblyAssetTrackingInternal.HierarchicalLogHandler {
+        return self
+    }
+    
+    public func logMessage(level: LogLevel, message: String, error: Error?) {}
+}

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -5,11 +5,12 @@ import AblyAssetTrackingSubscriber
 @testable import AblyAssetTrackingPublisher
 import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingPublisherTesting
+import AblyAssetTrackingInternalTesting
 
 class ChannelModesTests: XCTestCase {
     private let defaultDelayTime: TimeInterval = 10.0
     private let didUpdateEnhancedLocationExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Enhanced Locations")
-    let logger = LogHandlerMock()
+    let logger = MockHierarchicalLogHandler()
     
     func testShouldCreateOnlyOnePublisherAndOneSubscriberConnection() throws {
         let subscriberClientId = "Test-Subscriber_\(UUID().uuidString)"

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -7,6 +7,7 @@ import CoreLocation
 @testable import AblyAssetTrackingPublisher
 import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingPublisherTesting
+import AblyAssetTrackingInternalTesting
 
 struct Locations: Codable {
     let locations: [GeoJSONMessage]
@@ -32,7 +33,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         "Test-Publisher_\(UUID().uuidString)"
     }()
     
-    private let logger = LogHandlerMock()
+    private let logger = MockHierarchicalLogHandler()
     
     override func setUpWithError() throws { }
     override func tearDownWithError() throws { }


### PR DESCRIPTION
This adds a tag like `[assetTracking.subsystem1.subsystem2]` to each log message, identifying which subsystem (which might be a type, or might be the ably-cocoa SDK) emitted the message.

For example, a log from ably-cocoa inside the Publisher SDK would be tagged `[assetTracking.publisher.DefaultAbly.ablySDK]`. (This might turn out to be a little too verbose, but we can tweak that later.)

This allows us to always identify the output of the ably-cocoa SDK, and also allows us to remove all of the ad-hoc logging of `Self.self`.

Relates to #494.