### PR TITLE
LogParser: Properly extract the message and error description from example app logs

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
@@ -11,17 +11,18 @@ class PublisherLogger: AblyAssetTrackingCore.LogHandler {
     
     func logMessage(level: LogLevel, message: String, error: Error?) {
         let errorString = error?.localizedDescription
-        switch level {
-        case .verbose:
-            logger.log(level: .trace, "\(message). \(errorString ?? "")")
-        case .info:
-            logger.log(level: .info, "\(message). \(errorString ?? "")")
-        case .debug:
-            logger.log(level: .debug, "\(message). \(errorString ?? "")")
-        case .warn:
-            logger.log(level: .warning, "\(message). \(errorString ?? "")")
-        case .error:
-            logger.log(level: .error, "\(message). \(errorString ?? "")")
+        logger.log(level: level.swiftLogLevel, "\(message). \(errorString ?? "")")
+    }
+}
+
+private extension LogLevel {
+    var swiftLogLevel: Logger.Level {
+        switch self {
+        case .verbose: return .trace
+        case .info: return .info
+        case .debug: return .debug
+        case .warn: return .warning
+        case .error: return .error
         }
     }
 }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/PublisherLogger.swift
@@ -10,8 +10,17 @@ class PublisherLogger: AblyAssetTrackingCore.LogHandler {
     }
     
     func logMessage(level: LogLevel, message: String, error: Error?) {
-        let errorString = error?.localizedDescription
-        logger.log(level: level.swiftLogLevel, "\(message). \(errorString ?? "")")
+        let prefix: String
+
+        if let error = error {
+            // The LogParser library needs to be able to extract the error description from the log message; for this reason we emit its length
+            let errorDescription = error.localizedDescription
+            prefix = "[error(len:\(errorDescription.count)): \(errorDescription)] "
+        } else {
+            prefix = "[noError] "
+        }
+        
+        logger.log(level: level.swiftLogLevel, "\(prefix)\(message)")
     }
 }
 

--- a/Examples/SubscriberExample/Sources/Screens/Logging/SubscriberLogger.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Logging/SubscriberLogger.swift
@@ -11,17 +11,18 @@ class SubscriberLogger: AblyAssetTrackingCore.LogHandler {
     
     func logMessage(level: LogLevel, message: String, error: Error?) {
         let errorString = error?.localizedDescription
-        switch level {
-        case .verbose:
-            logger.log(level: .trace, "\(message). \(errorString ?? "")")
-        case .info:
-            logger.log(level: .info, "\(message). \(errorString ?? "")")
-        case .debug:
-            logger.log(level: .debug, "\(message). \(errorString ?? "")")
-        case .warn:
-            logger.log(level: .warning, "\(message). \(errorString ?? "")")
-        case .error:
-            logger.log(level: .error, "\(message). \(errorString ?? "")")
+        logger.log(level: level.swiftLogLevel, "\(message). \(errorString ?? "")")
+    }
+}
+
+private extension LogLevel {
+    var swiftLogLevel: Logger.Level {
+        switch self {
+        case .verbose: return .trace
+        case .info: return .info
+        case .debug: return .debug
+        case .warn: return .warning
+        case .error: return .error
         }
     }
 }

--- a/Examples/SubscriberExample/Sources/Screens/Logging/SubscriberLogger.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Logging/SubscriberLogger.swift
@@ -10,8 +10,17 @@ class SubscriberLogger: AblyAssetTrackingCore.LogHandler {
     }
     
     func logMessage(level: LogLevel, message: String, error: Error?) {
-        let errorString = error?.localizedDescription
-        logger.log(level: level.swiftLogLevel, "\(message). \(errorString ?? "")")
+        let prefix: String
+
+        if let error = error {
+            // The LogParser library needs to be able to extract the error description from the log message; for this reason we emit its length
+            let errorDescription = error.localizedDescription
+            prefix = "[error(len:\(errorDescription.count)): \(errorDescription)] "
+        } else {
+            prefix = "[noError] "
+        }
+        
+        logger.log(level: level.swiftLogLevel, "\(prefix)\(message)")
     }
 }
 

--- a/Tools/Library/LogParser/Tests/LogParserTests/ExampleAppLogFileTests.swift
+++ b/Tools/Library/LogParser/Tests/LogParserTests/ExampleAppLogFileTests.swift
@@ -4,9 +4,10 @@ import LogParser
 class ExampleAppLogFileTests: XCTestCase {
     func test_init_parsesExampleAppLogOutputData() throws {
         let text = """
-        2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.someComponent] Here is a message
+        2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.someComponent] Here is a message
         Some other line
-        2022-12-13T09:06:10.729000-03:00 info: [assetTracking.someOtherComponent]@(MyFile.swift:130) Here is another message
+        2022-12-13T09:06:10.729000-03:00 info: [noError] [assetTracking.someOtherComponent]@(MyFile.swift:130) Here is another message
+        2022-12-13T09:06:32.282000-03:00 error: [error(len:24): Here is an error message] [assetTracking.someComponent] Here is a message with an attached error
         """
         let data = try XCTUnwrap(text.data(using: .utf8))
         
@@ -17,13 +18,21 @@ class ExampleAppLogFileTests: XCTestCase {
                        logLevel: "debug",
                        message: .init(subsystems: ["assetTracking", "someComponent"],
                                       codeLocation: nil,
-                                      message: "Here is a message"))),
+                                      message: "Here is a message"),
+                       errorMessage: nil)),
             .other("Some other line"),
             .sdk(.init(timestamp: Date(timeIntervalSince1970: 1670933170.729),
                        logLevel: "info",
                        message: .init(subsystems: ["assetTracking", "someOtherComponent"],
                                       codeLocation: .init(file: "MyFile.swift", line: 130),
-                                      message: "Here is another message"))),
+                                      message: "Here is another message"),
+                       errorMessage: nil)),
+            .sdk(.init(timestamp: Date(timeIntervalSince1970: 1670933192.282),
+                       logLevel: "error",
+                       message: .init(subsystems: ["assetTracking", "someComponent"],
+                                      codeLocation: nil,
+                                      message: "Here is a message with an attached error"),
+                       errorMessage: "Here is an error message")),
         ]
         
         XCTAssertEqual(exampleAppLogFile.lines, expectedLines)

--- a/Tools/Library/LogParser/Tests/LogParserTests/ExampleAppSDKLogLineTests.swift
+++ b/Tools/Library/LogParser/Tests/LogParserTests/ExampleAppSDKLogLineTests.swift
@@ -3,21 +3,21 @@ import LogParser
 
 class ExampleAppSDKLogLineTests: XCTestCase {
     func test_init_withLogLineEmittedBySDK_parsesTimestamp() throws {
-        let line = "2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
+        let line = "2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
         let result = try ExampleAppSDKLogLine(line: line)
         
         XCTAssertEqual(result.timestamp, Date(timeIntervalSince1970: 1670933166.341))
     }
     
     func test_init_withLogLineEmittedBySDK_parsesLogLevel() throws {
-        let line = "2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
+        let line = "2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
         let result = try ExampleAppSDKLogLine(line: line)
         
         XCTAssertEqual(result.logLevel, "debug")
     }
     
     func test_init_withLogLineEmittedBySDK_parsesMessage() throws {
-        let line = "2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
+        let line = "2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
         let result = try ExampleAppSDKLogLine(line: line)
         
         let expectedMessage = SDKLogMessage(
@@ -29,10 +29,24 @@ class ExampleAppSDKLogLineTests: XCTestCase {
     }
 
     func test_init_withLogLineEmittedBySDK_withTrailingLineTerminator_parsesMessage_strippingLineTerminator() throws {
-        let line = "2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online.\n"
+        let line = "2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online.\n"
         let result = try ExampleAppSDKLogLine(line: line)
         
         XCTAssertEqual(result.message.message, "ablyPublisher.didChangeConnectionState. State: ConnectionState.online.")
+    }
+    
+    func test_init_withLogLineEmittedBySDK_withNoError_hasNilErrorMessage() throws {
+        let line = "2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
+        let result = try ExampleAppSDKLogLine(line: line)
+        
+        XCTAssertNil(result.errorMessage)
+    }
+    
+    func test_init_withLogLineEmittedBySDK_withError_parsesErrorMessage() throws {
+        let line = "2022-12-13T09:06:06.341000-03:00 error: [error(len:24): Here is an error message] [assetTracking.publisher.DefaultPublisher]@(DefaultPublisher.swift:906) ablyPublisher.didChangeConnectionState. State: ConnectionState.online."
+        let result = try ExampleAppSDKLogLine(line: line)
+        
+        XCTAssertEqual(result.errorMessage, "Here is an error message")
     }
     
     func test_init_withLogLineNotFromSDK_throwsError() {

--- a/Tools/Library/LogParserExample/example.txt
+++ b/Tools/Library/LogParserExample/example.txt
@@ -1,3 +1,4 @@
-2022-12-13T09:06:06.341000-03:00 debug: [assetTracking.someComponent] Here is a message
+2022-12-13T09:06:06.341000-03:00 debug: [noError] [assetTracking.someComponent] Here is a message
 Some other line
-2022-12-13T09:06:10.729000-03:00 info: [assetTracking.someOtherComponent]@(MyFile.swift:130) Here is another message
+2022-12-13T09:06:10.729000-03:00 info: [noError] [assetTracking.someOtherComponent]@(MyFile.swift:130) Here is another message
+2022-12-13T09:06:32.282000-03:00 info: [error(len:24): Here is an error message] [assetTracking.someComponent] Here is a message with an attached error


### PR DESCRIPTION
This removes this caveat from `ExampleAppSDKLogLine#message`:

> The ``SDKLogMessage/message`` of this value is not necessarily the exact value that was passed as the `message` argument of AblyAssetTrackingCore’s `LogHandler.logMessage(level:message:error:)`.  It may contain a suffix added by the example apps’ log handlers, to add a trailing full stop and information about the `error` argument.

Now, `#message` contains the exact value passed as the `message` argument to `LogHandler.logMessage(level:message:error:)`, and `#errorDescription` contains the `localizedDescription` of the error passed as the `error` argument to that method.

I want access to the exact log message emitted by the SDK, without any additional characters, so that I can for example emit some JSON in a log message from the SDK and then parse this JSON in an app that reads the logs.