### PR TITLE
Publisher example: Add a setting for logging `LocationHistoryData` JSON

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/SettingsModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/SettingsModel.swift
@@ -67,6 +67,15 @@ class SettingsModel {
         }
     }
     
+    var logLocationHistoryJSON: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: "logLocationHistoryJSON")
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "logLocationHistoryJSON")
+        }
+    }
+    
     var vehicleProfile: VehicleProfile {
         get {
             guard let profile: VehicleProfile = UserDefaults.standard.get("vehicleProfile") else {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Settings/SettingsView.swift
@@ -45,6 +45,15 @@ struct SettingsView: View {
             } header: {
                 Text("Other settings")
             }
+            
+            Section {
+                Toggle(isOn: $viewModel.logLocationHistoryJSON) {
+                    Text("Log location history JSON")
+                    Text("Causes the app to emit a `debug` level log message when a `LocationHistoryData` is received from the Asset Tracking SDK. The log message will contain a JSON serialization of this history data.")
+                }
+            } header: {
+                Text("Developer settings")
+            }
         }
         .listStyle(.grouped)
         .navigationBarTitle("Settings")

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -136,7 +136,7 @@ class CreatePublisherViewModel: ObservableObject {
         
         let configInfo = ObservablePublisher.PublisherConfigInfo(areRawLocationsEnabled: areRawLocationsEnabled, constantResolution: constantResolution)
         
-        let observablePublisher = ObservablePublisher(publisher: publisher, configInfo: configInfo, locationHistoryDataHandler: locationHistoryDataHandler)
+        let observablePublisher = ObservablePublisher(publisher: publisher, configInfo: configInfo, locationHistoryDataHandler: locationHistoryDataHandler, logger: logger)
         publisher.delegate = observablePublisher
         
         return observablePublisher

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/SettingsViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/SettingsViewModel.swift
@@ -9,6 +9,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
     
+    @Published var logLocationHistoryJSON: Bool = SettingsModel.shared.logLocationHistoryJSON {
+        didSet {
+            SettingsModel.shared.logLocationHistoryJSON = logLocationHistoryJSON
+        }
+    }
+    
     @Published var defaultResolutionMinimumDisplacement: String  = "\(SettingsModel.shared.defaultResolution.minimumDisplacement)"
     @Published var defaultResolutionDesiredInterval: String  = "\(SettingsModel.shared.defaultResolution.desiredInterval)"
     


### PR DESCRIPTION
While testing a fix for #425, I wanted to have access to the location history data in a log message.

This adds a switch in a new "Developer settings" section of the Settings page, which when turned on will emit a JSON serialization of the location history data when it’s received from the SDK. It’s turned off by default, because it's only for my specific use case.

<img src="https://user-images.githubusercontent.com/53756884/207951058-096a42f3-e56a-4460-8ad9-6f8a32910748.png" width=40% height=40%>