### PR TITLE
Rename example apps’ logger classes

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/SwiftLogLogHandler.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Logger/SwiftLogLogHandler.swift
@@ -2,7 +2,8 @@ import Foundation
 import AblyAssetTrackingCore
 import Logging
 
-class SubscriberLogger: AblyAssetTrackingCore.LogHandler {
+/// An implementation of ``AblyAssetTrackingCore.LogHandler`` which writes to an instance of the `swift-log` library’s ``Logger`` type.
+class SwiftLogLogHandler: AblyAssetTrackingCore.LogHandler {
     private let logger: Logger
         
     init(logger: Logger) {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/CreatePublisherViewModel.swift
@@ -129,7 +129,7 @@ class CreatePublisherViewModel: ObservableObject {
             .resolutionPolicyFactory(DefaultResolutionPolicyFactory(defaultResolution: resolution))
             .rawLocations(enabled: areRawLocationsEnabled)
             .constantLocationEngineResolution(resolution: constantResolution)
-            .logHandler(handler: PublisherLogger(logger: logger))
+            .logHandler(handler: SwiftLogLogHandler(logger: logger))
             .vehicleProfile(vehicleProfile)
             .start()
         

--- a/Examples/SubscriberExample/Sources/Screens/Logging/SwiftLogLogHandler.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Logging/SwiftLogLogHandler.swift
@@ -2,7 +2,8 @@ import Foundation
 import AblyAssetTrackingCore
 import Logging
 
-class PublisherLogger: AblyAssetTrackingCore.LogHandler {
+/// An implementation of ``AblyAssetTrackingCore.LogHandler`` which writes to an instance of the `swift-log` library’s ``Logger`` type.
+class SwiftLogLogHandler: AblyAssetTrackingCore.LogHandler {
     private let logger: Logger
         
     init(logger: Logger) {

--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
@@ -53,13 +53,13 @@ class MapViewController: UIViewController {
         
         return handler
     }
-    private let subscriberLogger: SubscriberLogger
+    private let subscriberLogger: SwiftLogLogHandler
 
     private var location: CLLocation?
 
     // MARK: - Initialization
     init(trackingId: String) {
-        self.subscriberLogger = SubscriberLogger(logger: logger)
+        self.subscriberLogger = SwiftLogLogHandler(logger: logger)
         
         self.trackingId = trackingId
         self.locationAnimator = DefaultLocationAnimator(logHandler: subscriberLogger)


### PR DESCRIPTION
The “Publisher” and “Subscriber” are extraneous given where these files live, and furthermore these classes are identical so it doesn’t make sense to distinguish them by name. Instead, give them both the same name, one which says something useful about their implementation.