### PR TITLE
Set up logging in system tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,10 @@ To open the project in the Xcode IDE, double click on the `Package.swift` file.
 
 To run tests from Xcode IDE, select the `ably-asset-tracking-swift-Package` scheme, select **_Product_** **_\-> Test_** _or use the keyboard shortcut_ **⌘U**
 
+## Enabling logging in system tests
+
+By default, the system tests disable SDK logging, to avoid leaking sensitive information (such as Ably API keys) in a CI environment. If you want to enable the logging to debug an issue on your development machine, use Xcode to set the `ABLY_ASSET_TRACKING_TESTS_ENABLE_LOGGING` environment variable to 1.
+
 ## Building Platform-Specific Documentation
 
 _This repo uses_ [_jazzy_](https://github.com/realm/jazzy) _to build documentation._

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ let package = Package(
         .testTarget(
             name: "SystemTests",
             dependencies: [
+                "AblyAssetTrackingTesting",
                 "AblyAssetTrackingCoreTesting",
                 "AblyAssetTrackingSubscriberTesting",
                 "AblyAssetTrackingPublisherTesting",
@@ -110,6 +111,14 @@ let package = Package(
                 "AblyAssetTrackingCoreTesting",
                 "AblyAssetTrackingUI"
             ]),
+        .target(
+            name: "AblyAssetTrackingTesting",
+            dependencies: [
+                "AblyAssetTrackingCore",
+                "AblyAssetTrackingInternal"
+            ],
+            path: "Tests/Support/AblyAssetTrackingTesting"
+        ),
         .target(
             name: "AblyAssetTrackingCoreTesting",
             dependencies: [

--- a/Tests/Support/AblyAssetTrackingTesting/TestLogging.swift
+++ b/Tests/Support/AblyAssetTrackingTesting/TestLogging.swift
@@ -1,0 +1,42 @@
+import Foundation
+import AblyAssetTrackingCore
+import AblyAssetTrackingInternal
+
+/// Provides shared logger instances for use by tests.
+public enum TestLogging {
+    /// A shared implementation of ``LogHandler``, which logs using ``NSLog``.
+    public static let sharedLogHandler: LogHandler = TestLogHandler()
+
+    /// A shared implementation of ``InternalLogHandler``, which wraps ``sharedLogHandler``.
+    public static let sharedInternalLogHandler: InternalLogHandler = DefaultInternalLogHandler(logHandler: sharedLogHandler)!
+}
+
+/// An implementation of ``LogHandler``, which logs using ``NSLog``.
+///
+/// By default, it does not write any log messages, to avoid leaking sensitive information (such as Ably API keys) in a CI environment. If you’re running the tests on your development machine, enable logging by setting the `ABLY_ASSET_TRACKING_TESTS_ENABLE_LOGGING` environment variable to 1.
+private class TestLogHandler: AblyAssetTrackingCore.LogHandler {
+    private let isLoggingEnabled: Bool = {
+        let isEnabled = ProcessInfo.processInfo.environment["ABLY_ASSET_TRACKING_TESTS_ENABLE_LOGGING"] == "1"
+
+        if !isEnabled {
+            NSLog("Ably Asset Tracking SDK logging is disabled by default when testing, to avoid leaking sensitive information in a CI environment. If you’re running the tests on your development machine, enable logging by setting the ABLY_ASSET_TRACKING_TESTS_ENABLE_LOGGING environment variable to 1.")
+        }
+
+        return isEnabled
+    }()
+
+    public func logMessage(level: LogLevel, message: String, error: Error?) {
+        guard isLoggingEnabled else {
+            return
+        }
+
+        let suffix: String
+        if let error = error {
+            suffix = " (error: \(error.localizedDescription))"
+        } else {
+            suffix = ""
+        }
+
+        NSLog("\(level): \(message)\(suffix)")
+    }
+}

--- a/Tests/Support/README.md
+++ b/Tests/Support/README.md
@@ -1,0 +1,7 @@
+# Ably Asset Tracking SDKs Test Support Libraries
+
+This directory contains libraries to help with testing the Ably Asset Tracking SDKs.
+
+## Library-specific test support libraries
+
+Given a library `SomeLib`, the `SomeLibTesting` library contains types that are useful for testing `SomeLib` or libraries that use `SomeLib` as a dependency. For example, it might contain mocks of the types contained in `SomeLib`.

--- a/Tests/Support/README.md
+++ b/Tests/Support/README.md
@@ -2,6 +2,10 @@
 
 This directory contains libraries to help with testing the Ably Asset Tracking SDKs.
 
+## General test support library
+
+The `AblyAssetTrackingTesting` library contains functionality that is generally useful for testing the Ably Asset Tracking SDKs, and which isn’t related to any specific library.
+
 ## Library-specific test support libraries
 
 Given a library `SomeLib`, the `SomeLibTesting` library contains types that are useful for testing `SomeLib` or libraries that use `SomeLib` as a dependency. For example, it might contain mocks of the types contained in `SomeLib`.

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -6,12 +6,12 @@ import AblyAssetTrackingSubscriber
 import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingPublisherTesting
 import AblyAssetTrackingInternalTesting
+import AblyAssetTrackingTesting
 
 class ChannelModesTests: XCTestCase {
     private let defaultDelayTime: TimeInterval = 10.0
     private let didUpdateEnhancedLocationExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Enhanced Locations")
-    let logger = InternalLogHandlerMock.configured
-    
+
     func testShouldCreateOnlyOnePublisherAndOneSubscriberConnection() throws {
         let subscriberClientId = "Test-Subscriber_\(UUID().uuidString)"
         let publisherClientId = "Test-Publisher_\(UUID().uuidString)"
@@ -64,11 +64,13 @@ class ChannelModesTests: XCTestCase {
     
     private func createPublisher(clientId: String, ablyApiKey: String) throws -> Publisher  {
         let locationsData = try LocalDataHelper.parseJsonFromResources("test-locations", type: Locations.self)
+
+        let internalLogHandler = TestLogging.sharedInternalLogHandler.addingSubsystem(.named("publisher"))
         
         let defaultLocationService = DefaultLocationService(
             mapboxConfiguration: .init(mapboxKey: Secrets.mapboxAccessToken),
             historyLocation: locationsData.locations.map({ $0.toCoreLocation() }),
-            logHandler: logger,
+            logHandler: internalLogHandler,
             vehicleProfile: VehicleProfile.car
         )
         let publisherConnectionConfiguration = ConnectionConfiguration(apiKey: ablyApiKey, clientId: clientId)
@@ -77,7 +79,7 @@ class ChannelModesTests: XCTestCase {
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
-            logHandler: logger
+            logHandler: internalLogHandler
         )
         
         return DefaultPublisher(
@@ -88,7 +90,7 @@ class ChannelModesTests: XCTestCase {
             ablyPublisher: defaultAbly,
             locationService: defaultLocationService,
             routeProvider: MockRouteProvider(),
-            logHandler: logger
+            logHandler: internalLogHandler
         )
         
     }
@@ -102,6 +104,7 @@ class ChannelModesTests: XCTestCase {
             .resolution(resolution)
             .delegate(self)
             .trackingId(trackableId)
+            .logHandler(handler: TestLogging.sharedLogHandler)
             .start(completion: { _ in })!
     }
     

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -8,6 +8,7 @@ import CoreLocation
 import AblyAssetTrackingCoreTesting
 import AblyAssetTrackingPublisherTesting
 import AblyAssetTrackingInternalTesting
+import AblyAssetTrackingTesting
 
 struct Locations: Codable {
     let locations: [GeoJSONMessage]
@@ -33,7 +34,8 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         "Test-Publisher_\(UUID().uuidString)"
     }()
     
-    private let logger = InternalLogHandlerMock.configured
+    private let logHandler = TestLogging.sharedLogHandler
+    private let publisherInternalLogHandler = TestLogging.sharedInternalLogHandler.addingSubsystem(.named("publisher"))
     
     override func setUpWithError() throws { }
     override func tearDownWithError() throws { }
@@ -61,6 +63,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             .resolution(resolution)
             .delegate(self)
             .trackingId(trackableId)
+            .logHandler(handler: logHandler)
             .start(completion: { _ in })!
         
         delay(5)
@@ -68,7 +71,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let defaultLocationService = DefaultLocationService(
             mapboxConfiguration: .init(mapboxKey: Secrets.mapboxAccessToken),
             historyLocation: locationsData.locations.map({ $0.toCoreLocation() }),
-            logHandler: logger,
+            logHandler: publisherInternalLogHandler,
             vehicleProfile: vehicleProfile
         )
         
@@ -78,7 +81,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
-            logHandler: logger
+            logHandler: publisherInternalLogHandler
         )
         
         let publisher = DefaultPublisher(
@@ -91,7 +94,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             routeProvider: routeProvider,
             areRawLocationsEnabled: true,
             isSendResolutionEnabled: true,
-            logHandler: logger
+            logHandler: publisherInternalLogHandler
         )
         
         
@@ -130,6 +133,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             .resolution(resolution)
             .delegate(self)
             .trackingId(trackableId)
+            .logHandler(handler: logHandler)
             .start(completion: { _ in })!
         
         delay(5)
@@ -160,7 +164,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let defaultLocationService = DefaultLocationService(
             mapboxConfiguration: .init(mapboxKey: Secrets.mapboxAccessToken),
             historyLocation: locationsData.locations.map({ $0.toCoreLocation() }),
-            logHandler: logger,
+            logHandler: publisherInternalLogHandler,
             vehicleProfile: vehicleProfile
         )
         
@@ -170,7 +174,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
             mode: .publish,
-            logHandler: logger
+            logHandler: publisherInternalLogHandler
         )
         
         let publisher = DefaultPublisher(
@@ -183,7 +187,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             routeProvider: routeProvider,
             areRawLocationsEnabled: true,
             isSendResolutionEnabled: true,
-            logHandler: logger
+            logHandler: publisherInternalLogHandler
         )
         
         let trackable = Trackable(id: trackableId)


### PR DESCRIPTION
In the upcoming `NetworkConnectivityTests` we’ll definitely want to be able to see the log output from the Asset Tracking SDKs. So, here I’ve added some ready-made log handlers that can be used by all of the tests, and added logging to the existing system tests (where, again, I think it’s useful to be able to see the SDKs’ logs sometimes).

The logging implementation uses `NSLog`. I wanted to use `swift-log`, like in the example apps, to give us the option of using our `LogParser` library to parse the logs. But adding `swift-log` as a dependency – even if one whose products are only used by the tests – affects the dependency graph of the entire package. Specifically, it could cause a version requirements clash for other packages that use the AAT SDKs and also have their own dependency on `swift-log`. See [this Swift Forums post](https://forums.swift.org/t/test-only-dependencies/3888/14):

> The only part of the picture that isn’t finished yet is that unused dependencies still affect the version compatibilities of your dependency graph.