### PR TITLE
Remove unused properties from `DefaultPublisher`

### DIFF
--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -18,7 +18,6 @@ class DefaultPublisher: Publisher {
     }
     
     private let workingQueue: DispatchQueue
-    private let connectionConfiguration: ConnectionConfiguration
     private let locationService: LocationService
     private let resolutionPolicy: ResolutionPolicy
     private let routeProvider: RouteProvider
@@ -67,8 +66,7 @@ class DefaultPublisher: Publisher {
     private(set) public var activeTrackable: Trackable?
     private(set) public var routingProfile: RoutingProfile
 
-    init(connectionConfiguration: ConnectionConfiguration,
-         routingProfile: RoutingProfile,
+    init(routingProfile: RoutingProfile,
          resolutionPolicyFactory: ResolutionPolicyFactory,
          ablyPublisher: AblyPublisher,
          locationService: LocationService,
@@ -80,8 +78,6 @@ class DefaultPublisher: Publisher {
          constantLocationEngineResolution: Resolution? = nil,
          logHandler: InternalLogHandler?
     ) {
-        
-        self.connectionConfiguration = connectionConfiguration
         self.routingProfile = routingProfile
         self.workingQueue = DispatchQueue(label: "io.ably.asset-tracking.Publisher.DefaultPublisher", qos: .default)
         self.locationService = locationService

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -19,7 +19,6 @@ class DefaultPublisher: Publisher {
     
     private let workingQueue: DispatchQueue
     private let connectionConfiguration: ConnectionConfiguration
-    private let mapboxConfiguration: MapboxConfiguration
     private let locationService: LocationService
     private let resolutionPolicy: ResolutionPolicy
     private let routeProvider: RouteProvider
@@ -69,7 +68,6 @@ class DefaultPublisher: Publisher {
     private(set) public var routingProfile: RoutingProfile
 
     init(connectionConfiguration: ConnectionConfiguration,
-         mapboxConfiguration: MapboxConfiguration,
          routingProfile: RoutingProfile,
          resolutionPolicyFactory: ResolutionPolicyFactory,
          ablyPublisher: AblyPublisher,
@@ -84,7 +82,6 @@ class DefaultPublisher: Publisher {
     ) {
         
         self.connectionConfiguration = connectionConfiguration
-        self.mapboxConfiguration = mapboxConfiguration
         self.routingProfile = routingProfile
         self.workingQueue = DispatchQueue(label: "io.ably.asset-tracking.Publisher.DefaultPublisher", qos: .default)
         self.locationService = locationService

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -68,7 +68,6 @@ class DefaultPublisherBuilder: PublisherBuilder {
         )
         
         let publisher =  DefaultPublisher(connectionConfiguration: connection,
-                                          mapboxConfiguration: mapboxConfiguration,
                                           routingProfile: routingProfile,
                                           resolutionPolicyFactory: resolutionPolicyFactory,
                                           ablyPublisher: defaultAbly,

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -67,8 +67,7 @@ class DefaultPublisherBuilder: PublisherBuilder {
             logHandler: hierarchicalLogHandler
         )
         
-        let publisher =  DefaultPublisher(connectionConfiguration: connection,
-                                          routingProfile: routingProfile,
+        let publisher =  DefaultPublisher(routingProfile: routingProfile,
                                           resolutionPolicyFactory: resolutionPolicyFactory,
                                           ablyPublisher: defaultAbly,
                                           locationService: DefaultLocationService(mapboxConfiguration: mapboxConfiguration, historyLocation: locationSource?.locations, logHandler: hierarchicalLogHandler, vehicleProfile: vehicleProfile),

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -13,7 +13,6 @@ class DefaultPublisherTests: XCTestCase {
     var locationService: MockLocationService!
     var ablyPublisher: MockAblyPublisher!
     var configuration: ConnectionConfiguration!
-    var mapboxConfiguration: MapboxConfiguration!
     var routeProvider: MockRouteProvider!
     var resolutionPolicyFactory: MockResolutionPolicyFactory!
     var trackable: Trackable!
@@ -28,7 +27,6 @@ class DefaultPublisherTests: XCTestCase {
         configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
         locationService = MockLocationService()
         ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish)
-        mapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN")
         resolutionPolicyFactory = MockResolutionPolicyFactory()
         routeProvider = MockRouteProvider()
         trackable = Trackable(id: "TrackableId",
@@ -37,7 +35,6 @@ class DefaultPublisherTests: XCTestCase {
         delegate = MockPublisherDelegate()
         enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
         publisher = DefaultPublisher(connectionConfiguration: configuration,
-                                     mapboxConfiguration: mapboxConfiguration,
                                      routingProfile: .driving,
                                      resolutionPolicyFactory: resolutionPolicyFactory,
                                      ablyPublisher: ablyPublisher,
@@ -998,7 +995,6 @@ class DefaultPublisherTests: XCTestCase {
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
-            mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -34,8 +34,7 @@ class DefaultPublisherTests: XCTestCase {
                               destination: LocationCoordinate(latitude: 3.1415, longitude: 2.7182))
         delegate = MockPublisherDelegate()
         enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
-        publisher = DefaultPublisher(connectionConfiguration: configuration,
-                                     routingProfile: .driving,
+        publisher = DefaultPublisher(routingProfile: .driving,
                                      resolutionPolicyFactory: resolutionPolicyFactory,
                                      ablyPublisher: ablyPublisher,
                                      locationService: locationService,
@@ -994,7 +993,6 @@ class DefaultPublisherTests: XCTestCase {
         locationService.stopRecordingLocationCallback = { completion in completion(.success(nil)) }
         
         let publisher = DefaultPublisher(
-            connectionConfiguration: configuration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -41,7 +41,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         )
         
         publisher = DefaultPublisher(
-            connectionConfiguration:configuration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,
@@ -319,7 +318,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         let publisher = DefaultPublisher(
-            connectionConfiguration: configuration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,
@@ -355,7 +353,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         ablyPublisher.connectCompletionHandler = { completion in  completion?(.success) }
         
         let publisher = DefaultPublisher(
-            connectionConfiguration: configuration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -12,7 +12,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     var locationService: MockLocationService!
     var ablyPublisher: MockAblyPublisher!
     var configuration: ConnectionConfiguration!
-    var mapboxConfiguration: MapboxConfiguration!
     var resolutionPolicyFactory: MockResolutionPolicyFactory!
     var routeProvider: MockRouteProvider!
     var trackable: Trackable!
@@ -27,7 +26,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         locationService = MockLocationService()
         configuration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID")
         ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish)
-        mapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN")
         routeProvider = MockRouteProvider()
         resolutionPolicyFactory = MockResolutionPolicyFactory()
         delegate = MockPublisherDelegate()
@@ -44,7 +42,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         
         publisher = DefaultPublisher(
             connectionConfiguration:configuration,
-            mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,
@@ -323,7 +320,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
-            mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,
@@ -360,7 +356,6 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         
         let publisher = DefaultPublisher(
             connectionConfiguration: configuration,
-            mapboxConfiguration: mapboxConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -90,7 +90,6 @@ class PublisherHelper {
     static func createPublisher(
         ablyPublisher: AblyPublisher,
         connectionConfiguration: ConnectionConfiguration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID"),
-        mapboxConfiguration: MapboxConfiguration = MapboxConfiguration(mapboxKey: "MAPBOX_ACCESS_TOKEN"),
         routingProfile: RoutingProfile = .driving,
         resolutionPolicyFactory: ResolutionPolicyFactory = MockResolutionPolicyFactory(),
         locationService: LocationService = MockLocationService(),
@@ -101,7 +100,6 @@ class PublisherHelper {
         
         DefaultPublisher(
             connectionConfiguration: connectionConfiguration,
-            mapboxConfiguration: mapboxConfiguration,
             routingProfile: routingProfile,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -89,7 +89,6 @@ class PublisherHelper {
     
     static func createPublisher(
         ablyPublisher: AblyPublisher,
-        connectionConfiguration: ConnectionConfiguration = ConnectionConfiguration(apiKey: "API_KEY", clientId: "CLIENT_ID"),
         routingProfile: RoutingProfile = .driving,
         resolutionPolicyFactory: ResolutionPolicyFactory = MockResolutionPolicyFactory(),
         locationService: LocationService = MockLocationService(),
@@ -99,7 +98,6 @@ class PublisherHelper {
     ) -> DefaultPublisher {
         
         DefaultPublisher(
-            connectionConfiguration: connectionConfiguration,
             routingProfile: routingProfile,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: ablyPublisher,

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -81,7 +81,6 @@ class ChannelModesTests: XCTestCase {
         )
         
         return DefaultPublisher(
-            connectionConfiguration: publisherConnectionConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: MockResolutionPolicyFactory(),
             ablyPublisher: defaultAbly,

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -82,7 +82,6 @@ class ChannelModesTests: XCTestCase {
         
         return DefaultPublisher(
             connectionConfiguration: publisherConnectionConfiguration,
-            mapboxConfiguration: MapboxConfiguration(mapboxKey: Secrets.mapboxAccessToken),
             routingProfile: .driving,
             resolutionPolicyFactory: MockResolutionPolicyFactory(),
             ablyPublisher: defaultAbly,

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -83,7 +83,6 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         
         let publisher = DefaultPublisher(
             connectionConfiguration: publisherConnectionConfiguration,
-            mapboxConfiguration: MapboxConfiguration(mapboxKey: Secrets.mapboxAccessToken),
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: defaultAbly,
@@ -175,7 +174,6 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         
         let publisher = DefaultPublisher(
             connectionConfiguration: publisherConnectionConfiguration,
-            mapboxConfiguration: MapboxConfiguration(mapboxKey: Secrets.mapboxAccessToken),
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: defaultAbly,

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -82,7 +82,6 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         )
         
         let publisher = DefaultPublisher(
-            connectionConfiguration: publisherConnectionConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: defaultAbly,
@@ -173,7 +172,6 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         )
         
         let publisher = DefaultPublisher(
-            connectionConfiguration: publisherConnectionConfiguration,
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
             ablyPublisher: defaultAbly,


### PR DESCRIPTION
This removes the unused `mapboxConfiguration` and `connectionConfiguration` properties from `DefaultPublisher`.