### PR TITLE
Fix early-exit bug in `ConnectionConfiguration.getClientOptions`

### DIFF
--- a/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
@@ -14,7 +14,6 @@ extension ConnectionConfiguration {
         
         if let authCallback = authCallback {
             clientOptions.authCallback = createAuthCallback(authCallback)
-            return clientOptions
         } else {
             clientOptions.key = apiKey
         }


### PR DESCRIPTION
For some reason, this method was exiting early when an `authCallback` was specified. This definitely seems like an accident, and I can’t find anything to suggest any motivation for it — all of the skipped code seems like it should be run even in the presence of an `authCallback`.