### PR TITLE
Make `InternalARTLogHandler` directly use an `InternalLogHandler` instance

### DIFF
--- a/Sources/AblyAssetTrackingInternal/Logging/InternalARTLogHandler.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/InternalARTLogHandler.swift
@@ -3,12 +3,35 @@ import Ably
 import AblyAssetTrackingCore
 
 /**
-* This log handler is supposed to be used only for capturing internal events from the ably-cocoa sdk and passing them on
-* to the LogHandler (passed by users via publisher/subscriber builder methods) via `logCallback`
-*/
+ * This log handler provides an subclass of the ably-cocoa SDK’s ``ARTLog`` class.
+ * It forwards the log messages to a given instance of ``InternalLogHandler``.
+ */
 public class InternalARTLogHandler: ARTLog {
-    var logCallback: ((_ message: String, _ level: LogLevel, _ error: Error?) -> Void)?
-    
+    private let logHandler: InternalLogHandler?
+
+    public init(logHandler: InternalLogHandler?) {
+        self.logHandler = logHandler?.addingSubsystem(.named("ablySDK"))
+    }
+
+    private func log(_ message: String, level: LogLevel, error: Error?) {
+        // We don't add line numbers to messages emitted by ably-cocoa,
+        // since it doesn’t expose that information to us through the
+        // ARTLog interface. Also, some (but not all) log messages from
+        // ably-cocoa already include line number information.
+        switch level {
+        case .verbose:
+            logHandler?.verbose(message: message, error: error, file: nil, line: nil)
+        case .info:
+            logHandler?.info(message: message, error: error, file: nil, line: nil)
+        case .debug:
+            logHandler?.debug(message: message, error: error, file: nil, line: nil)
+        case .warn:
+            logHandler?.warn(message: message, error: error, file: nil, line: nil)
+        case .error:
+            logHandler?.error(message: message, error: error, file: nil, line: nil)
+        }
+    }
+
     private func convertLogLevel(artLogLevel: ARTLogLevel) -> LogLevel {
         switch artLogLevel {
         case .verbose:
@@ -28,11 +51,11 @@ public class InternalARTLogHandler: ARTLog {
     
     override public func log(_ message: String, with level: ARTLogLevel) {
         let convertedLogLevel = convertLogLevel(artLogLevel: level)
-        logCallback?(message, convertedLogLevel, nil)
+        log(message, level: convertedLogLevel, error: nil)
     }
     
     override public func logWithError(_ error: ARTErrorInfo) {
         let convertedLogLevel = convertLogLevel(artLogLevel: .error)
-        logCallback?(error.message, convertedLogLevel, error)
+        log(error.message, level: convertedLogLevel, error: nil)
     }
 }

--- a/Tests/InternalTests/Configuration/ConnectionConfiguration+ExtensionsTests.swift
+++ b/Tests/InternalTests/Configuration/ConnectionConfiguration+ExtensionsTests.swift
@@ -5,7 +5,7 @@ import AblyAssetTrackingCore
 
 class ConnectionConfigurationTests: XCTestCase {
 
-    let internalARTLogHandler = InternalARTLogHandler()
+    let internalARTLogHandler = InternalARTLogHandler(logHandler: nil)
     
     func testBasicAuthenticationConstructor() throws {
         let configuration = ConnectionConfiguration(apiKey: "An API key", clientId: "A client ID")


### PR DESCRIPTION
We don’t need the generality of the callback. I want to reuse this class in the tests; the more code we can reuse, the better.