### PR TITLE
Don’t always use "assetTracking" as first component of `DefaultInternalLogHandler`

### DIFF
--- a/Sources/AblyAssetTrackingInternal/Logging/DefaultInternalLogHandler.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/DefaultInternalLogHandler.swift
@@ -8,20 +8,17 @@ public struct DefaultInternalLogHandler: InternalLogHandler {
     private var logHandler: LogHandler
     private var subsystemNames: [String] // Lowest granularity first
     
-    /// Creates an instance of ``DefaultInternalLogHandler`` that writes messages to a given ``LogHandler``. The lowest-granularity subsystem of the returned log handler will always be "assetTracking".
+    /// Creates an instance of ``DefaultInternalLogHandler`` that writes messages to a given ``LogHandler``.
     /// - Parameters:
     ///   - logHandler: A log handler to write messages to. If this is nil, the initializer will return nil.
-    ///   - subsystem: A subsystem to add to the list
-    public init?(logHandler: LogHandler?, subsystem: Subsystem? = nil) {
+    ///   - subsystems: The log handler’s initial list of subsystems, in order of increasing granularity.
+    public init?(logHandler: LogHandler?, subsystems: [Subsystem] = []) {
         guard let logHandler = logHandler else {
             return nil
         }
         self.logHandler = logHandler
-        
-        self.subsystemNames = ["assetTracking"]
-        if let subsystem = subsystem {
-            self.subsystemNames.append(subsystem.name)
-        }
+
+        self.subsystemNames = subsystems.map(\.name)
     }
     
     public func logMessage(level: LogLevel, message: String, error: Error?, codeLocation: CodeLocation?) {

--- a/Sources/AblyAssetTrackingInternal/Logging/InternalLogHandler.swift
+++ b/Sources/AblyAssetTrackingInternal/Logging/InternalLogHandler.swift
@@ -1,7 +1,9 @@
 import AblyAssetTrackingCore
 
-/// A description of some component of the SDK which wishes to identify itself in a log message.
+/// A description of some software component which wishes to identify itself in a log message.
 public enum Subsystem {
+    // One of the Ably Asset Tracking SDKs.
+    case assetTracking
     /// An arbitrary component with a name.
     case named(String)
     /// A component that is a Swift type.
@@ -10,6 +12,8 @@ public enum Subsystem {
     /// The text that will be used to identify this component in a log message.
     var name: String {
         switch self {
+        case .assetTracking:
+            return "assetTracking"
         case .named(let name):
             return name
         case .typed(let type):

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -58,7 +58,7 @@ class DefaultPublisherBuilder: PublisherBuilder {
         }
         
         let internalLogHandler = DefaultInternalLogHandler(logHandler: logHandler,
-                                                           subsystem: .named("publisher"))
+                                                           subsystems: [.assetTracking, .named("publisher")])
         
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
@@ -39,7 +39,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
         }
         
         let internalLogHandler = DefaultInternalLogHandler(logHandler: logHandler,
-                                                           subsystem: .named("subscriber"))
+                                                           subsystems: [.assetTracking, .named("subscriber")])
 
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),

--- a/Sources/AblyAssetTrackingUI/LocationAnimator/DefaultLocationAnimator.swift
+++ b/Sources/AblyAssetTrackingUI/LocationAnimator/DefaultLocationAnimator.swift
@@ -42,7 +42,7 @@ public class DefaultLocationAnimator: NSObject, LocationAnimator {
     }
     
     public init(logHandler: LogHandler? = nil) {
-        self.logHandler = DefaultInternalLogHandler(logHandler: logHandler, subsystem: .typed(Self.self))
+        self.logHandler = DefaultInternalLogHandler(logHandler: logHandler, subsystems: [.assetTracking, .typed(Self.self)])
         super.init()
         
         displayLinkTarget.locationAnimator = self

--- a/Tests/InternalTests/DefaultInternalLogHandlerTests.swift
+++ b/Tests/InternalTests/DefaultInternalLogHandlerTests.swift
@@ -9,7 +9,7 @@ class DefaultInternalLogHandlerTests: XCTestCase {
     
     func test_addSubsystem_causesLoggedMessagesToIncludeSubsystemName() throws {
         let underlyingLogHandler = LogHandlerMock()
-        let logHandler = try XCTUnwrap(DefaultInternalLogHandler(logHandler: underlyingLogHandler))
+        let logHandler = try XCTUnwrap(DefaultInternalLogHandler(logHandler: underlyingLogHandler, subsystems: [.assetTracking]))
             .addingSubsystem(.named("myComponent"))
 
         logHandler.logMessage(level: .info, message: "Here is a message", error: nil, codeLocation: nil)
@@ -22,7 +22,7 @@ class DefaultInternalLogHandlerTests: XCTestCase {
     
     func test_logMessage_withNonNilCodeLocation_includesLastPathComponentOfFileAndIncludesLineNumber() throws {
         let underlyingLogHandler = LogHandlerMock()
-        let logHandler = try XCTUnwrap(DefaultInternalLogHandler(logHandler: underlyingLogHandler))
+        let logHandler = try XCTUnwrap(DefaultInternalLogHandler(logHandler: underlyingLogHandler, subsystems: [.assetTracking]))
         
         let codeLocation = CodeLocation(file: "/path/to/the/MyFile.swift", line: 130)
         logHandler.logMessage(level: .info, message: "Here is a message", error: nil, codeLocation: codeLocation)

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -65,7 +65,9 @@ class ChannelModesTests: XCTestCase {
     private func createPublisher(clientId: String, ablyApiKey: String) throws -> Publisher  {
         let locationsData = try LocalDataHelper.parseJsonFromResources("test-locations", type: Locations.self)
 
-        let internalLogHandler = TestLogging.sharedInternalLogHandler.addingSubsystem(.named("publisher"))
+        let internalLogHandler = TestLogging.sharedInternalLogHandler
+            .addingSubsystem(.assetTracking)
+            .addingSubsystem(.named("publisher"))
         
         let defaultLocationService = DefaultLocationService(
             mapboxConfiguration: .init(mapboxKey: Secrets.mapboxAccessToken),

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -35,7 +35,9 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
     }()
     
     private let logHandler = TestLogging.sharedLogHandler
-    private let publisherInternalLogHandler = TestLogging.sharedInternalLogHandler.addingSubsystem(.named("publisher"))
+    private let publisherInternalLogHandler = TestLogging.sharedInternalLogHandler
+        .addingSubsystem(.assetTracking)
+        .addingSubsystem(.named("publisher"))
     
     override func setUpWithError() throws { }
     override func tearDownWithError() throws { }


### PR DESCRIPTION
I want to use an instance of this logger to log messages emitted directly by test cases, and in those situations I want to be able to set a different initial component.