### PR TITLE
Add functionality for running parameterized tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,10 +114,16 @@ let package = Package(
         .target(
             name: "AblyAssetTrackingTesting",
             dependencies: [
+                "AblyAssetTrackingTestingObjC",
                 "AblyAssetTrackingCore",
                 "AblyAssetTrackingInternal"
             ],
             path: "Tests/Support/AblyAssetTrackingTesting"
+        ),
+        .target(
+            name: "AblyAssetTrackingTestingObjC",
+            dependencies:[],
+            path: "Tests/Support/AblyAssetTrackingTestingObjC"
         ),
         .target(
             name: "AblyAssetTrackingCoreTesting",

--- a/Tests/Support/AblyAssetTrackingTesting/ParameterizedTestCase.swift
+++ b/Tests/Support/AblyAssetTrackingTesting/ParameterizedTestCase.swift
@@ -1,0 +1,201 @@
+import AblyAssetTrackingTestingObjC
+
+/// A type by which a ``ParameterizedTestCase`` subclass is parameterized.
+public protocol ParameterizedTestCaseParam {
+    /// The string that this parameter should contribute to name of the test method that ``ParameterizedTestCase`` will generate for this parameter.
+    ///
+    /// If it contains characters that are not allowed in a method name, they will be escaped.
+    ///
+    /// If there are multiple parameters with the same ``methodNameComponent`` in a single test case, the behaviour is currently undefined.
+    var methodNameComponent: String { get }
+}
+
+/// An `XCTestCase` subclass that is capable of running parameterized tests.
+///
+/// A _parameterized test_ is an instance method with the same signature as a normal test method, but whose name starts with `parameterizedTest` instead of `test`. Like a normal test method, this method can also be specified as `throws`. However, `async` parameterized tests are not currently supported.
+///
+/// `ParameterizedTestCase` begins its execution by fetching all of the parameters that it will use. It does this by calling its ``fetchParams(_:)`` class method, which subclasses must override.
+///
+/// It then generates a test method corresponding to each combination of parameterized test and parameter. This method calls the corresponding parameterized test method.
+///
+/// Before running a test method corresponding to a given parameter value, it sets the test case’s ``currentParam`` value. The ``currentParam`` value is also available within the test case’s ``setUp...`` methods.
+///
+/// In order to use the Xcode GUI to run an individual test, you must first run the whole test file so that Xcode can become aware of the test’s existence. You can then re-run the test using Xcode’s Test navigator.
+open class ParameterizedTestCase<Param: ParameterizedTestCaseParam> : AATParameterizedTestCaseObjC {
+    // Constant for the lifetime of the test case instance
+    private var _currentParam: Param?
+
+    /// The parameter value that the currently-executing test case should use.
+    public var currentParam: Param {
+        guard let _currentParam else {
+            fatalError("Attempted to fetch currentParam before it was populated. Did you try to fetch it before setUp?")
+        }
+        return _currentParam
+    }
+
+    /// Asynchronously fetch the parameters that this test case will use. Subclasses must implement this method.
+    ///
+    /// The test case imposes a timeout of 10 seconds on this operation.
+    ///
+    /// - Parameters:
+    ///     - completion: A handler that you must call with the fetched results or an error.
+    open class func fetchParams(_ completion: @escaping (Result<[Param], Error>) -> Void) {
+        fatalError("fetchParams: must be implemented by subclasses")
+    }
+
+    /// Override of `NSObject` method, needed for running a single test.
+    ///
+    /// When `xctest` runs a test for a single test method (e.g. when triggered via the gutter play button in Xcode), it does not call `defaultTestSuite` on the test class but rather calls
+    /// `instancesRespondToSelector:`. So, our usual strategy of relying on `defaultTestSuite` to create the test methods will not work in this situation, and we instead use `instancesRespondToSelector:` as our opportunity to do so.
+    open override class func instancesRespond(to aSelector: Selector!) -> Bool {
+        self.aat_createTestMethods()
+
+        return super.instancesRespond(to: aSelector)
+    }
+
+    /// `xctest` calls this method before calling any of the `setUp...` methods, so we can use it to set ``currentParam`` such that it’s accessible by those methods.
+    open override func invokeTest() {
+        guard let fetchedParam =  ParameterizedTestCaseParamStorage.shared.param(forTestMethodNamed: aat_invocationSelector, inClass: Self.self) else {
+            fatalError("Could not find stored param for method \(aat_invocationSelector) in \(Self.self)")
+        }
+        _currentParam = fetchedParam
+
+        super.invokeTest()
+    }
+
+    /// This implementation is required by our superclass `AATParameterizedTestCaseObjC`.
+    @discardableResult
+    open override class func aat_createTestMethods() -> [String] {
+        let logHandler = TestLogging.sharedInternalLogHandler.addingSubsystem(.typed(self))
+
+        let params: [Param]
+        do {
+            params = try Blocking.run(label: "Fetch params for running parameterized test cases", timeout: 10, logHandler: logHandler) { handler in
+                fetchParams(handler)
+            }
+        } catch {
+            // I can’t really think of much we can do here other than blow up the test process to bring this failure to people’s attention
+            fatalError("Failed to fetch params in \(self): \(error)")
+        }
+
+        return parameterizedTestMethodSelectors.flatMap { selector in
+            params.map { param in
+                let selector = aliasParameterizedTestMethod(named: selector, forParam: param)
+                ParameterizedTestCaseParamStorage.shared.setParam(param, forTestMethodNamed: selector, inClass: self)
+                return NSStringFromSelector(selector)
+            }
+        }
+    }
+
+    /// Returns a list of selectors for all of this class’s instance methods whose name starts with `parameterizedTest`.
+    private class var parameterizedTestMethodSelectors: [Selector] {
+        var count: UInt32 = 0
+        let list = class_copyMethodList(self, &count)!
+
+        let allInstanceMethodSelectors = (0..<Int32(count)).map {
+            let method = list[Int($0)]
+            return method_getName(method)
+        }
+
+        free(list)
+
+        return allInstanceMethodSelectors.filter { selector in
+            NSStringFromSelector(selector).hasPrefix("parameterizedTest")
+        }
+    }
+
+    /// Aliases a parameterized test method to a normal test method by creating a new instance method with the same implementation but a different name.
+    private static func aliasParameterizedTestMethod(named name: Selector, forParam param: Param) -> Selector {
+        let method = class_getInstanceMethod(self, name)!
+        let implementation = method_getImplementation(method)
+        let typeEncoding = method_getTypeEncoding(method)
+
+        let testMethodName = testMethodName(forParameterizedTestMethodNamed: name, param: param)
+        class_addMethod(self, testMethodName, implementation, typeEncoding)
+
+        return testMethodName
+    }
+
+    /// Creates a test method name for a parameterized test method and a parameter value.
+    ///
+    /// Given a method name of the form `parameterizedTestFooBar` and a parameter whose `methodNameComponent` is `someParamValue`, returns `testFooBar_someParamValue`.
+    ///
+    /// It also supports method names of the form `parameterizedTestFooBarAndReturnError:`, which are how `throw`-ing test cases are exposed to Objective-C. In this case, it will return `testFooBar_someParamValueAndReturnError:`
+    private static func testMethodName(forParameterizedTestMethodNamed name: Selector, param: Param) -> Selector {
+        let nameWithParamInserted = insertingParam(param, intoParameterizedTestMethodNamed: name)
+        return changingParameterizedTestToTest(nameWithParamInserted)
+    }
+
+    /// Inserts the `methodNameComponent` of a parameter value into a parameterized test method name method name.
+    ///
+    /// Given a method name of the form `parameterizedTestFooBar` and a parameter whose `methodNameComponent` is `someParamValue`, returns `parameterizedTestFooBar_someParamValue`.
+    ///
+    /// It also supports method names of the form `parameterizedTestFooBarAndReturnError:`, which are how `throw`-ing test cases are exposed to Objective-C. In this case, it will return `parameterizedTestFooBar_someParamValueAndReturnError:`
+    ///
+    /// - Parameters:
+    ///     - param: A parameter value.
+    ///     - name: The selector of the parameterized test method.
+    private static func insertingParam(_ param: Param, intoParameterizedTestMethodNamed name: Selector) -> Selector {
+        var result = NSStringFromSelector(name)
+
+        let insertionIndex: String.Index
+
+        let andReturnError = "AndReturnError:"
+        if result.hasSuffix(andReturnError) {
+            let range = result.range(of: andReturnError, options: [.backwards])!
+
+            insertionIndex = range.lowerBound
+        } else if result.contains(":") {
+            // I think we’ll hit this case if we specify an `async` parameterized test, which is presumably exposed to Objective-C as a method that takes a completion handler. We can address this later if we need to, but for now I’ve stated in the class description that async parameterized tests are not supported.
+            fatalError("Don’t know how to rename method \(name)")
+        } else {
+            insertionIndex = result.endIndex
+        }
+
+        result.insert(contentsOf: "_\(param.methodNameComponent.c99ExtendedIdentifier)", at: insertionIndex)
+
+        return Selector(result)
+    }
+
+    /// Replaces a `"parameterizedTest"` prefix with `"test"`.
+    ///
+    /// - Parameters:
+    ///     - name: A selector which begins with `"parameterizedTest"`.
+    private static func changingParameterizedTestToTest(_ name: Selector) -> Selector {
+        var result = NSStringFromSelector(name)
+        let parameterizedTestRange = result.range(of: "parameterizedTest")!
+        result.removeSubrange(parameterizedTestRange)
+        result.insert(contentsOf: "test", at: result.startIndex)
+
+        return Selector(result)
+    }
+}
+
+// This code for escaping strings for insertion into a method name is copied from the Quick testing framework: https://github.com/Quick/Quick/blob/43c1d3dc9e18c02065dc8a9c75ec586ab46e7be9/Sources/Quick/String%2BC99ExtendedIdentifier.swift#L4-L30
+private extension String {
+    private static var invalidCharacters: CharacterSet = {
+        var invalidCharacters = CharacterSet()
+
+        let invalidCharacterSets: [CharacterSet] = [
+            .whitespacesAndNewlines,
+            .illegalCharacters,
+            .controlCharacters,
+            .punctuationCharacters,
+            .nonBaseCharacters,
+            .symbols,
+        ]
+
+        for invalidSet in invalidCharacterSets {
+            invalidCharacters.formUnion(invalidSet)
+        }
+
+        return invalidCharacters
+    }()
+
+    var c99ExtendedIdentifier: String {
+        let validComponents = components(separatedBy: String.invalidCharacters)
+        let result = validComponents.joined(separator: "_")
+
+        return result.isEmpty ? "_" : result
+    }
+}

--- a/Tests/Support/AblyAssetTrackingTesting/ParameterizedTestCaseParamStorage.swift
+++ b/Tests/Support/AblyAssetTrackingTesting/ParameterizedTestCaseParamStorage.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Provides storage for the parameter values corresponding to each generated test method of ``ParameterizedTestCase`` subclasses.
+struct ParameterizedTestCaseParamStorage {
+    static var shared = ParameterizedTestCaseParamStorage()
+    private init() {}
+
+    /// Provides a "unique" identifier for a type such that it can be used as a hash key.
+    ///
+    /// I’m not sure under exactly what circumstances the return value of `String(describing: type)` uniquely describes the type, but I think it’s good enough for our immediate needs.
+    ///
+    /// I tried various ways of implementing the `ParameterizedTestCaseParamStorage` class in the hopes that I could avoid this `TypeID` and have a type-safe, generic `MethodNameKeyedParamStorage`, but I didn’t get anywhere (it always ended up involving a cast somewhere, and the cast always failed for reasons I couldn’t get my head around).
+    private struct TypeID: Hashable {
+        private let id: String
+
+        init(type: Any.Type) {
+            self.id = String(describing: type)
+        }
+    }
+
+    private var perTypeStorages: [TypeID : MethodNameKeyedParamStorage] = [:]
+
+    private struct MethodNameKeyedParamStorage {
+        private var paramsByTestMethodName: [Selector : Any] = [:]
+
+        mutating func setParam(_ param: Any, forTestMethodNamed name: Selector) {
+            paramsByTestMethodName[name] = param
+        }
+
+        func param(forTestMethodNamed name: Selector) -> Any? {
+            return paramsByTestMethodName[name]
+        }
+    }
+
+    /// Stores the parameter corresponding to the test method names `name` in class `containingClass`.
+    mutating func setParam<TestClass, Param>(_ param: Param, forTestMethodNamed name: Selector, inClass containingClass: TestClass.Type) where TestClass: ParameterizedTestCase<Param> {
+        let typeID = TypeID(type: containingClass)
+
+        if let storage = perTypeStorages[typeID] {
+            var newStorage = storage
+            newStorage.setParam(param, forTestMethodNamed: name)
+            perTypeStorages[typeID] = newStorage
+        } else {
+            var storage = MethodNameKeyedParamStorage()
+            storage.setParam(param, forTestMethodNamed: name)
+            perTypeStorages[typeID] = storage
+        }
+    }
+
+    /// Retrieves the parameter corresponding to the test method named `name` in class `containingClass`.
+    func param<TestClass, Param>(forTestMethodNamed name: Selector, inClass containingClass: TestClass.Type) -> Param? where TestClass: ParameterizedTestCase<Param> {
+        let typeID = TypeID(type: containingClass)
+        return perTypeStorages[typeID]?.param(forTestMethodNamed: name) as? Param
+    }
+}

--- a/Tests/Support/AblyAssetTrackingTestingObjC/AATParameterizedTestCaseObjC.m
+++ b/Tests/Support/AblyAssetTrackingTestingObjC/AATParameterizedTestCaseObjC.m
@@ -1,0 +1,38 @@
+#import "AATParameterizedTestCaseObjC.h"
+
+@implementation AATParameterizedTestCaseObjC
+
+/// An override of the corresponding `XCTestCase` method, which allows us to specify the test methods that should be executed. This is where we can dynamically create test methods.
++ (NSArray<NSInvocation *> *)testInvocations {
+    if (self == [AATParameterizedTestCaseObjC class]) {
+        // The XCTest runtime will call +[AATParameterizedTestCaseObjC testInvocations] when
+        // enumerating all of the XCTestCase subclasses. We don’t want to call through to
+        // +aat_createTestMethods as that will trigger an unimplemented method exception.
+        return [super testInvocations];
+    }
+
+    NSArray<NSString *> *testMethodSelectorStrings = [self aat_createTestMethods];
+    NSMutableArray<NSInvocation *> *invocations = [NSMutableArray array];
+
+    // Copied from https://github.com/Quick/Quick/blob/43c1d3d/Sources/QuickObjCRuntime/QuickSpecBase.m#L20-L29
+    for (NSString *selectorString in testMethodSelectorStrings) {
+        SEL selector = NSSelectorFromString(selectorString);
+        NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.selector = selector;
+
+        [invocations addObject:invocation];
+    }
+
+    return invocations;
+}
+
++ (NSArray<NSString *> *)aat_createTestMethods {
+    [NSException raise:@"AATParameterizedTestCaseException" format:@"aat_createTestMethods must be implemented by subclasses"];
+}
+
+- (SEL)aat_invocationSelector {
+    return self.invocation.selector;
+}
+
+@end

--- a/Tests/Support/AblyAssetTrackingTestingObjC/include/AATParameterizedTestCaseObjC.h
+++ b/Tests/Support/AblyAssetTrackingTestingObjC/include/AATParameterizedTestCaseObjC.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// An `XCTestCase` subclass that serves as a base class for `AblyAssetTrackingTesting.ParameterizedTestCase`. It implements the parts of that class which can’t be implemented in Swift due to the unavailability of `NSInvocation`.
+@interface AATParameterizedTestCaseObjC : XCTestCase
+
+/// Creates all of the test methods (that is, instance methods whose name begins with `test_`) that this class wishes `xctest` to run. Subclasses must implement this method.
+///
+/// - Returns: A list of `NSStringFromSelector`-ified selectors which name all of the created methods.
++ (NSArray<NSString *> *)aat_createTestMethods;
+
+/// Returns `self.invocation.selector`.
+@property (readonly) SEL aat_invocationSelector;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## What does this do?

For our upcoming `NetworkConnectivityTests`, we want to run a predefined list of test cases for all of the faults currently known to the SDK test proxy server.

On Android, we use JUnit’s `@Parameterized` functionality to do this.  There isn’t a corresponding thing in `XCTest`, so here we build one.

The general approach (where to hook into the Objective-C runtime and `XCTest` callbacks) is inspired by the implementation of the [Quick testing framework](https://github.com/Quick/Quick).

## How to review

There are two commits; one to provide the functionality and another to add an example parameterized test case. I’d suggest looking at the example and the documentation for `ParameterizedTestCase` before looking at the implementation (if you even want to look at the implementation, that is; I don't think it's hugely important if you don't want to get into those weeds).

## An example of a parameterized test in action

### Running all the tests in a file

https://user-images.githubusercontent.com/53756884/222514148-aabf10f1-bf3e-4a84-b238-1f73ca2eec8b.mov

### Running a single test

You need to first of all run all the tests in the file to make Xcode aware of the test, then you can re-run it individually:

https://user-images.githubusercontent.com/53756884/222514599-28c1aec4-1f1a-4c90-b31d-87d1c9dc2fa0.mov
