### PR TITLE
Add ability to internally specify custom Ably host

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -14,11 +14,11 @@ public class DefaultAbly: AblyCommon {
     
     private var channels: [String: AblySDKRealtimeChannel] = [:]
 
-    public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, mode: AblyMode, logHandler: InternalLogHandler?) {
+    public required init(factory: AblySDKRealtimeFactory, configuration: ConnectionConfiguration, host: Host?, mode: AblyMode, logHandler: InternalLogHandler?) {
         self.logHandler = logHandler?.addingSubsystem(Self.self)
         
         let internalARTLogHandler = InternalARTLogHandler(logHandler: self.logHandler)
-        self.client = factory.create(withConfiguration: configuration, logHandler: internalARTLogHandler)
+        self.client = factory.create(withConfiguration: configuration, logHandler: internalARTLogHandler, host: host)
         
         self.mode = mode
         self.connectionConfiguration = configuration

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblyCocoaSDK.swift
@@ -125,8 +125,14 @@ struct AblyCocoaSDKEventListener: AblySDKEventListener {
 public class AblyCocoaSDKRealtimeFactory: AblySDKRealtimeFactory {
     public init() {}
     
-    public func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler) -> AblySDKRealtime {
-        let realtime = ARTRealtime(options: configuration.getClientOptions(logHandler: logHandler, remainPresentForMilliseconds: configuration.remainPresentForMilliseconds))
+    public func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler, host: Host?) -> AblySDKRealtime {
+        let clientOptions = configuration.getClientOptions(
+            logHandler: logHandler,
+            remainPresentForMilliseconds: configuration.remainPresentForMilliseconds,
+            host: host
+        )
+
+        let realtime = ARTRealtime(options: clientOptions)
         return AblyCocoaSDKRealtime(realtime: realtime)
     }
 }

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/SDK/AblySDKProtocols.swift
@@ -3,7 +3,7 @@ import AblyAssetTrackingCore
 
 //sourcery: AutoMockable
 public protocol AblySDKRealtimeFactory {
-    func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler) -> AblySDKRealtime
+    func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler, host: Host?) -> AblySDKRealtime
 }
 
 //sourcery: AutoMockable

--- a/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/ConnectionConfiguration+Extensions.swift
@@ -6,7 +6,7 @@ extension ConnectionConfiguration {
     /**
      Create ClientOptions for Ably SDK, to be passed to Ably Client
      */
-    public func getClientOptions(logHandler: InternalARTLogHandler, remainPresentForMilliseconds: Int?) -> ARTClientOptions {
+    public func getClientOptions(logHandler: InternalARTLogHandler, remainPresentForMilliseconds: Int?, host: Host?) -> ARTClientOptions {
         let clientOptions = ARTClientOptions()
         if let clientId = clientId {
             clientOptions.clientId = clientId
@@ -30,7 +30,13 @@ extension ConnectionConfiguration {
             let remainPresentForStringifiable = ARTStringifiable.withNumber(remainPresentForMilliseconds as NSNumber)
             clientOptions.transportParams = ["remainPresentFor": remainPresentForStringifiable]
         }
-        
+
+        if let host {
+            clientOptions.realtimeHost = host.realtimeHost
+            clientOptions.port = host.port
+            clientOptions.tls = host.tls
+        }
+
         return clientOptions
     }
     

--- a/Sources/AblyAssetTrackingInternal/Configuration/Host.swift
+++ b/Sources/AblyAssetTrackingInternal/Configuration/Host.swift
@@ -1,0 +1,12 @@
+/// Internal-only type for configuring some properties of `ARTClientOptions` which we do not wish to expose through the public `ConnectionConfiguration` interface. Intended for use in testing.
+public struct Host {
+    public var realtimeHost: String
+    public var port: Int
+    public var tls: Bool
+
+    public init(realtimeHost: String, port: Int, tls: Bool) {
+        self.realtimeHost = realtimeHost
+        self.port = port
+        self.tls = tls
+    }
+}

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherBuilder.swift
@@ -63,6 +63,7 @@ class DefaultPublisherBuilder: PublisherBuilder {
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
+            host: nil,
             mode: .publish,
             logHandler: internalLogHandler
         )

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberBuilder.swift
@@ -44,6 +44,7 @@ class DefaultSubscriberBuilder: SubscriberBuilder {
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: connection,
+            host: nil,
             mode: .subscribe,
             logHandler: internalLogHandler
         )

--- a/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
+++ b/Tests/InternalTests/AblyWrapper/DefaultAblyTests.swift
@@ -31,11 +31,11 @@ class DefaultAblyTests: XCTestCase {
         realtime.auth = auth
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration(apiKey: "abc123")
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly fails to connect")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -69,13 +69,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.channels = channels
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly successfully connects")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -109,13 +109,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.channels = channels
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly fails to connect")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -159,13 +159,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.auth = auth
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly fails to connect")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -217,13 +217,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.auth = auth
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly successfully connects")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -269,13 +269,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.auth = auth
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly fails to connect")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -317,13 +317,13 @@ class DefaultAblyTests: XCTestCase {
         realtime.auth = auth
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let expectation = expectation(description: "DefaultAbly fails to connect")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -374,11 +374,11 @@ class DefaultAblyTests: XCTestCase {
         realtime.channels = channels
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration(apiKey: "")
         
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         
         let connectSuccessExpectation = expectation(description: "DefaultAbly connects successfully")
         ably.connect(trackableId: "abc", presenceData: PresenceData(type: .subscriber), useRewind: false) { result in
@@ -427,14 +427,14 @@ class DefaultAblyTests: XCTestCase {
         realtime.channels = channels
         
         let factory = AblySDKRealtimeFactoryMock()
-        factory.createWithConfigurationLogHandlerReturnValue = realtime
+        factory.createWithConfigurationLogHandlerHostReturnValue = realtime
         
         let connectionConfiguration = ConnectionConfiguration { _, callback in
             callback(.success(.tokenDetails(.init(token: "", expires: Date(), issued: Date(), capability: "", clientId: ""))))
         }
         
         let trackableId = "abc"
-        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, mode: [], logHandler: logger)
+        let ably = DefaultAbly(factory: factory, configuration: connectionConfiguration, host: nil, mode: [], logHandler: logger)
         ably.connect(trackableId: trackableId, presenceData: .init(type: .subscriber), useRewind: false) { _ in }
         
         let subscriberDelegate = AblySubscriberDelegateMock()

--- a/Tests/InternalTests/Configuration/ConnectionConfiguration+ExtensionsTests.swift
+++ b/Tests/InternalTests/Configuration/ConnectionConfiguration+ExtensionsTests.swift
@@ -9,7 +9,7 @@ class ConnectionConfigurationTests: XCTestCase {
     
     func testBasicAuthenticationConstructor() throws {
         let configuration = ConnectionConfiguration(apiKey: "An API key", clientId: "A client ID")
-        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil)
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: nil)
         XCTAssertEqual(clientOptions.clientId, "A client ID")
         XCTAssertNil(clientOptions.authCallback)
     }
@@ -19,7 +19,7 @@ class ConnectionConfigurationTests: XCTestCase {
         let clientId = "My client id"
         let configuration = ConnectionConfiguration(clientId: clientId, authCallback: { _, _ in })
         
-        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil)
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: nil)
         
         XCTAssertEqual(clientOptions.clientId, clientId)
     }
@@ -39,7 +39,7 @@ class ConnectionConfigurationTests: XCTestCase {
         })
         
         // Checking the clientOptions provided is structured correctly for Ably-cocoa
-        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil)
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: nil)
         
         let clientId = "My client id"
         let tokenParams = TokenParams(ttl: 0, capability: "", clientId: clientId, timestamp: timestamp, nonce: nonce).toARTTokenParams()
@@ -70,7 +70,7 @@ class ConnectionConfigurationTests: XCTestCase {
             })
             
             // Checking the clientOptions provided is structured correctly for Ably-cocoa
-            let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil)
+            let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: nil)
             
             let clientId = "My client id"
             let tokenParams = TokenParams(ttl: 0, capability: "", clientId: clientId, timestamp: timestamp, nonce: nonce).toARTTokenParams()
@@ -99,7 +99,7 @@ class ConnectionConfigurationTests: XCTestCase {
         })
         
         // Checking the clientOptions provided is structured correctly for Ably-cocoa
-        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil)
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: nil)
         
         let tokenParams = TokenParams(ttl: 0, capability: "", clientId: "My client id", timestamp: timestamp, nonce: nonce).toARTTokenParams()
         XCTAssertNotNil(clientOptions.authCallback)
@@ -117,8 +117,19 @@ class ConnectionConfigurationTests: XCTestCase {
     func testRemainPresentForMillisecondsPassesToAblySDK() {
         let configuration = ConnectionConfiguration(apiKey: "An API key", clientId: "A client ID")
 
-        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: 100)
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: 100, host: nil)
         
         XCTAssertEqual(clientOptions.transportParams?["remainPresentFor"]?.stringValue, "100")
+    }
+
+    func testHostSetsCorrespondingPropertiesOnClientOptions() {
+        let configuration = ConnectionConfiguration(apiKey: "An API key", clientId: "A client ID")
+        let host = Host(realtimeHost: "something.example", port: 5678, tls: false)
+
+        let clientOptions = configuration.getClientOptions(logHandler: internalARTLogHandler, remainPresentForMilliseconds: nil, host: host)
+
+        XCTAssertEqual(clientOptions.realtimeHost, "something.example")
+        XCTAssertEqual(clientOptions.port, 5678)
+        XCTAssertEqual(clientOptions.tls, false)
     }
 }

--- a/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/GeneratedMocks.swift
+++ b/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/GeneratedMocks.swift
@@ -288,23 +288,23 @@ public class AblySDKRealtimeFactoryMock: AblySDKRealtimeFactory {
 
     //MARK: - create
 
-    public var createWithConfigurationLogHandlerCallsCount = 0
-    public var createWithConfigurationLogHandlerCalled: Bool {
-        return createWithConfigurationLogHandlerCallsCount > 0
+    public var createWithConfigurationLogHandlerHostCallsCount = 0
+    public var createWithConfigurationLogHandlerHostCalled: Bool {
+        return createWithConfigurationLogHandlerHostCallsCount > 0
     }
-    public var createWithConfigurationLogHandlerReceivedArguments: (configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler)?
-    public var createWithConfigurationLogHandlerReceivedInvocations: [(configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler)] = []
-    public var createWithConfigurationLogHandlerReturnValue: AblySDKRealtime!
-    public var createWithConfigurationLogHandlerClosure: ((ConnectionConfiguration, InternalARTLogHandler) -> AblySDKRealtime)?
+    public var createWithConfigurationLogHandlerHostReceivedArguments: (configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler, host: Host?)?
+    public var createWithConfigurationLogHandlerHostReceivedInvocations: [(configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler, host: Host?)] = []
+    public var createWithConfigurationLogHandlerHostReturnValue: AblySDKRealtime!
+    public var createWithConfigurationLogHandlerHostClosure: ((ConnectionConfiguration, InternalARTLogHandler, Host?) -> AblySDKRealtime)?
 
-    public func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler) -> AblySDKRealtime {
-        createWithConfigurationLogHandlerCallsCount += 1
-        createWithConfigurationLogHandlerReceivedArguments = (configuration: configuration, logHandler: logHandler)
-        createWithConfigurationLogHandlerReceivedInvocations.append((configuration: configuration, logHandler: logHandler))
-        if let createWithConfigurationLogHandlerClosure = createWithConfigurationLogHandlerClosure {
-            return createWithConfigurationLogHandlerClosure(configuration, logHandler)
+    public func create(withConfiguration configuration: ConnectionConfiguration, logHandler: InternalARTLogHandler, host: Host?) -> AblySDKRealtime {
+        createWithConfigurationLogHandlerHostCallsCount += 1
+        createWithConfigurationLogHandlerHostReceivedArguments = (configuration: configuration, logHandler: logHandler, host: host)
+        createWithConfigurationLogHandlerHostReceivedInvocations.append((configuration: configuration, logHandler: logHandler, host: host))
+        if let createWithConfigurationLogHandlerHostClosure = createWithConfigurationLogHandlerHostClosure {
+            return createWithConfigurationLogHandlerHostClosure(configuration, logHandler, host)
         } else {
-            return createWithConfigurationLogHandlerReturnValue
+            return createWithConfigurationLogHandlerHostReturnValue
         }
     }
 

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -80,6 +80,7 @@ class ChannelModesTests: XCTestCase {
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
+            host: nil,
             mode: .publish,
             logHandler: internalLogHandler
         )

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -82,6 +82,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
+            host: nil,
             mode: .publish,
             logHandler: publisherInternalLogHandler
         )
@@ -173,6 +174,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         let defaultAbly = DefaultAbly(
             factory: AblyCocoaSDKRealtimeFactory(),
             configuration: publisherConnectionConfiguration,
+            host: nil,
             mode: .publish,
             logHandler: publisherInternalLogHandler
         )


### PR DESCRIPTION
We need this for the upcoming `NetworkConnectivityTests`, so that we can connect to the local SDK test proxy.