### PR TITLE
Update Swift version in `Package.swift` to 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MapboxNavigation", url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.9.0"),
+        .package(url: "https://github.com/mapbox/mapbox-navigation-ios.git", from: "2.9.0"),
         .package(url: "https://github.com/ably/ably-cocoa", from: "1.2.19"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.1")
     ],
@@ -41,7 +41,7 @@ let package = Package(
                 "AblyAssetTrackingCore",
                 "AblyAssetTrackingInternal",
                 .product(name: "Ably", package: "ably-cocoa"),
-                .product(name: "MapboxNavigation", package: "MapboxNavigation"),
+                .product(name: "MapboxNavigation", package: "mapbox-navigation-ios"),
                 .product(name: "Version", package: "Version")
             ]),
         .target(


### PR DESCRIPTION
And address the deprecation warning this introduces.

This should have been done alongside c918aea.

I believe that this compiler version change introduces a new version (2) of `Package.resolved`, but calling `swift package resolve` alone doesn’t force the compiler to re-generate this file – seems like it will only do so next time we have an actual change in our resolved dependencies. So I’ll let it perform that migration when it needs to in the future.