### PR TITLE
Document that iOS 13 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Visit the [Ably Asset Tracking](https://ably.com/docs/asset-tracking) documentat
 
 These SDKs support support iOS and iPadOS. Support for macOS/ tvOS may be developed in the future, depending on interest/ demand.
 
-- Publisher SDK: iOS 12.0+ / iPadOS 12.0+
+- Publisher SDK: iOS 13.0+ / iPadOS 13.0+
 
-- Subscriber SDK: iOS 12.0+ / iPadOS 12.0+
+- Subscriber SDK: iOS 13.0+ / iPadOS 13.0+
 
 - Xcode 14.0+
 


### PR DESCRIPTION
Resolves #597.

Our `README` currently says that our minimum iOS version is 12 and above, and during the development of this SDK we have been working with this requirement in mind – for example by not using Swift concurrency, which is only available in iOS 13 and above.

Our `Package.swift` was however updated in eeb88b0 to require iOS 13 and above, without any explanation for this change.

To clear up this confusion, we have now spoken to clients to understand their iOS version requirements, and have found out that we can target iOS 13 for the subscriber SDK and iOS 14 for the publisher SDK.

For now, since there are no obvious features of the iOS 14 SDK that we need, I’ll keep a deployment target of iOS 13 for both SDKs, but we may wish to decouple them in the future so that they can have separate deployment targets.

See #613 for taking advantage of the now-available Swift concurrency features.

Internal threads re client requirements:

1. https://ably-real-time.slack.com/archives/C01EPJENRD0/p1677611526684719
2. https://ably-real-time.slack.com/archives/C01EPJENRD0/p1678698762445489