### PR TITLE
Add ability for `Blocking.run` to wait forever

### DIFF
--- a/Tests/Support/AblyAssetTrackingTesting/Blocking.swift
+++ b/Tests/Support/AblyAssetTrackingTesting/Blocking.swift
@@ -17,13 +17,13 @@ public enum Blocking {
     ///
     /// - Parameters:
     ///     - label: A description of the operation. Will be used for logging and error messages.
-    ///     - timeout: The maximum amount of time to wait for the operation to complete. If this duration is exceeded, then ``Blocking.Error.timedOut`` will be thrown.
+    ///     - timeout: The maximum amount of time to wait for the operation to complete. If this duration is exceeded, then ``Blocking.Error.timedOut`` will be thrown. If nil, then no timeout will be enforced, and this method will run until the operation completes or the wait is interrupted by an "outer" waiter (see ``Blocking.Error.interrupted``).
     ///     - logHandler: A log handler that this method will log to.
     ///     - operation: The operation to be executed.
     ///
     /// - Throws: ``Blocking.Error`` if the operation does not succeed, or if it times out or is interrupted by an "outer" ``XCTWaiter`` timing out first.
     /// - Returns: The operation’s result if it succeeds.
-    public static func run<Success, Failure>(label: String, timeout: TimeInterval, logHandler: InternalLogHandler, _ operation: (@escaping (Result<Success, Failure>) -> Void) -> Void) throws -> Success {
+    public static func run<Success, Failure>(label: String, timeout: TimeInterval?, logHandler: InternalLogHandler, _ operation: (@escaping (Result<Success, Failure>) -> Void) -> Void) throws -> Success {
         logHandler.debug(message: "Start Blocking.run (\(label))", error: nil)
 
         let waiter = XCTWaiter()
@@ -38,8 +38,16 @@ public enum Blocking {
             expectation.fulfill()
         }
 
-        logHandler.debug(message: "Blocking.run waiting for \(timeout)s for operation to complete (\(label))", error: nil)
-        let expectationWaitResult = waiter.wait(for: [expectation], timeout: timeout)
+
+        let waiterTimeout: TimeInterval
+        if let timeout {
+            logHandler.debug(message: "Blocking.run waiting for \(timeout)s for operation to complete (\(label))", error: nil)
+            waiterTimeout = timeout
+        } else {
+            logHandler.debug(message: "Blocking.run waiting indefinitely for operation to complete (\(label))", error: nil)
+            waiterTimeout = .greatestFiniteMagnitude
+        }
+        let expectationWaitResult = waiter.wait(for: [expectation], timeout: waiterTimeout)
 
         switch expectationWaitResult {
         case .completed:
@@ -53,7 +61,7 @@ public enum Blocking {
             }
         case .timedOut:
             logHandler.debug(message: "Blocking.run timed out (\(label))", error: nil)
-            throw Error.timedOut(duration: timeout, label: logHandler.tagMessage(label))
+            throw Error.timedOut(duration: waiterTimeout, label: logHandler.tagMessage(label))
         case .interrupted:
             logHandler.debug(message: "Blocking.run was interrupted (\(label))", error: nil)
             throw Error.interrupted(label: logHandler.tagMessage(label))


### PR DESCRIPTION
The `NetworkConnectivityTests` I’m working on rely on an outer waiter’s timeout interrupting an inner waiter, and so the inner waiter doesn’t need to specify its own timeout.