### PR TITLE
Log the result received from `Blocking.run`’s result handler

### DIFF
--- a/Tests/Support/AblyAssetTrackingTesting/Blocking.swift
+++ b/Tests/Support/AblyAssetTrackingTesting/Blocking.swift
@@ -33,7 +33,7 @@ public enum Blocking {
 
         logHandler.debug(message: "Perform Blocking.run’s operation (\(label))", error: nil)
         operation { asyncResult in
-            logHandler.debug(message: "Blocking.run’s operation called its result handler (\(label))", error: nil)
+            logHandler.debug(message: "Blocking.run’s operation called its result handler (\(label)) with result \(asyncResult)", error: nil)
             result = asyncResult
             expectation.fulfill()
         }


### PR DESCRIPTION
If the async operation itself contains a call to `Blocking.run`, then, when the outer timeout elapses, the inner call to `Blocking.run` will fail with an `interrupted` error. The result of this is that the outer operation’s result handler will get called with this interrupted error too. At the moment, though, the logs just say that the outer operation’s result handler was called, and that can be confusing since people might think that this means the outer operation succeeded, even though they’re about to see another message telling them it timed out.