### PR TITLE
Make usage of `ConnectionState` and `TrackableState` consistent with Android

### DIFF
--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		21E6EBF828F97B200057AC7C /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E6EBF728F97B200057AC7C /* Map.swift */; };
 		21F1992F28FF40B2004FE626 /* DummyPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F1992E28FF40B2004FE626 /* DummyPublisher.swift */; };
 		21F1993228FF40E6004FE626 /* PublisherDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F1993128FF40E6004FE626 /* PublisherDetailsView.swift */; };
-		21F1993428FF40F3004FE626 /* ConnectionState+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F1993328FF40F3004FE626 /* ConnectionState+Formatting.swift */; };
+		21F1993428FF40F3004FE626 /* TrackableState+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F1993328FF40F3004FE626 /* TrackableState+Formatting.swift */; };
 		21F1993628FF41B2004FE626 /* PublisherInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F1993528FF41B2004FE626 /* PublisherInfoViewModel.swift */; };
 		D544FAF62771B3560015925C /* PublisherExampleSwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D544FAF52771B3560015925C /* PublisherExampleSwiftUIApp.swift */; };
 		D544FAFA2771B3580015925C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D544FAF92771B3580015925C /* Assets.xcassets */; };
@@ -98,7 +98,7 @@
 		21E6EBF728F97B200057AC7C /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		21F1992E28FF40B2004FE626 /* DummyPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyPublisher.swift; sourceTree = "<group>"; };
 		21F1993128FF40E6004FE626 /* PublisherDetailsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublisherDetailsView.swift; sourceTree = "<group>"; };
-		21F1993328FF40F3004FE626 /* ConnectionState+Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConnectionState+Formatting.swift"; sourceTree = "<group>"; };
+		21F1993328FF40F3004FE626 /* TrackableState+Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TrackableState+Formatting.swift"; sourceTree = "<group>"; };
 		21F1993528FF41B2004FE626 /* PublisherInfoViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublisherInfoViewModel.swift; sourceTree = "<group>"; };
 		D544FAF22771B3560015925C /* PublisherExampleSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PublisherExampleSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D544FAF52771B3560015925C /* PublisherExampleSwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherExampleSwiftUIApp.swift; sourceTree = "<group>"; };
@@ -320,7 +320,7 @@
 			children = (
 				21B6B2A729097EAF001E2FB7 /* LocationSourceOption.swift */,
 				2108B758290974B8002778CA /* S3Helper.swift */,
-				21F1993328FF40F3004FE626 /* ConnectionState+Formatting.swift */,
+				21F1993328FF40F3004FE626 /* TrackableState+Formatting.swift */,
 				0CFCA306289131AB00A1A6B5 /* CloseKeyboardHelper.swift */,
 				0CFCA305289131AB00A1A6B5 /* UserDefaults+Codable.swift */,
 				D544FB4A277333A20015925C /* Environment.swift */,
@@ -459,7 +459,7 @@
 				2108B759290974B8002778CA /* S3Helper.swift in Sources */,
 				0CFCA300289130E700A1A6B5 /* TitleTextFieldListItem.swift in Sources */,
 				21F1993628FF41B2004FE626 /* PublisherInfoViewModel.swift in Sources */,
-				21F1993428FF40F3004FE626 /* ConnectionState+Formatting.swift in Sources */,
+				21F1993428FF40F3004FE626 /* TrackableState+Formatting.swift in Sources */,
 				0C9E6B1D28BBA637001A54E1 /* PublisherLogger.swift in Sources */,
 				21CF8E0328F875DF005E7CE6 /* SettingsView.swift in Sources */,
 				0CFCA308289131AB00A1A6B5 /* CloseKeyboardHelper.swift in Sources */,

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Helper/TrackableState+Formatting.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Helper/TrackableState+Formatting.swift
@@ -1,14 +1,12 @@
 import AblyAssetTrackingCore
 
-extension ConnectionState {
+extension TrackableState {
     func asInfo() -> String {
         switch self {
         case .online:
             return "Online"
         case .offline:
             return "Offline"
-        case .closed:
-            return "Closed"
         case .failed:
             return "Failed"
         }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/Model/ObservablePublisher.swift
@@ -14,10 +14,10 @@ class ObservablePublisher: ObservableObject {
         var constantResolution: Resolution?
     }
 
-    struct TrackableState {
-        var connectionState: ConnectionState?
+    struct ObservablePublisherTrackableState {
+        var trackableState: TrackableState?
     }
-    @Published private(set) var trackables: [Trackable: TrackableState] = [:]
+    @Published private(set) var trackables: [Trackable: ObservablePublisherTrackableState] = [:]
     @Published private(set) var location: EnhancedLocationUpdate?
     @Published private(set) var resolution: Resolution?
     @Published private(set) var routingProfile: RoutingProfile?
@@ -60,12 +60,12 @@ class ObservablePublisher: ObservableObject {
         }
     }
 
-    private func updateConnectionState(_ connectionState: ConnectionState, forTrackable trackable: Trackable) {
-        guard let trackableState = trackables[trackable] else {
+    private func updateState(_ trackableState: TrackableState, forTrackable trackable: Trackable) {
+        guard let observablePublisherTrackableState = trackables[trackable] else {
             return
         }
-        var newTrackableState = trackableState
-        newTrackableState.connectionState = connectionState
+        var newTrackableState = observablePublisherTrackableState
+        newTrackableState.trackableState = trackableState
         trackables[trackable] = newTrackableState
     }
 }
@@ -79,8 +79,8 @@ extension ObservablePublisher: PublisherDelegate {
         self.location = location
     }
 
-    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didChangeConnectionState state: AblyAssetTrackingCore.ConnectionState, forTrackable trackable: AblyAssetTrackingCore.Trackable) {
-        updateConnectionState(state, forTrackable: trackable)
+    func publisher(sender: AblyAssetTrackingPublisher.Publisher, didChangeState state: TrackableState, forTrackable trackable: Trackable) {
+        updateState(state, forTrackable: trackable)
     }
 
     func publisher(sender: AblyAssetTrackingPublisher.Publisher, didUpdateResolution resolution: AblyAssetTrackingCore.Resolution) {

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Map/MapView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/Map/MapView.swift
@@ -16,7 +16,7 @@ struct MapView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            StackedText(texts: MapViewModel.createViewModel(forConnectionState: publisher.trackables.first { key, _ in key.id == trackableId }?.value.connectionState))
+            StackedText(texts: MapViewModel.createViewModel(forTrackableState: publisher.trackables.first { key, _ in key.id == trackableId }?.value.trackableState))
                 .padding(.leading, 10)
             // This padding is very bad - for some reason, I wasn't able to tap on the "Remove trackable" button without it. I'm probably doing something very very wrong but don't have time to look into it now. See https://github.com/ably/ably-asset-tracking-swift/issues/422
                 .padding(.bottom, 25)

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/PublisherDetailsView.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/View/PublisherDetailsView.swift
@@ -15,7 +15,7 @@ struct PublisherDetailsView: View {
 
     @ObservedObject var publisher: ObservablePublisher
 
-    var sortedTrackables: [(trackable: Trackable, state: ObservablePublisher.TrackableState)] {
+    var sortedTrackables: [(trackable: Trackable, state: ObservablePublisher.ObservablePublisherTrackableState)] {
         publisher.trackables
             .sorted { pair1, pair2 in
                 pair1.key.id < pair2.key.id
@@ -40,7 +40,7 @@ struct PublisherDetailsView: View {
                             HStack {
                                 Text(info.trackable.id)
                                 Spacer()
-                                Text(info.state.connectionState?.asInfo() ?? "Connection state unknown")
+                                Text(info.state.trackableState?.asInfo() ?? "Trackable state unknown")
                             }
                         }
                     }

--- a/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/MapViewModel.swift
+++ b/Examples/PublisherExampleSwiftUI/PublisherExampleSwiftUI/ViewModel/MapViewModel.swift
@@ -6,7 +6,7 @@ class MapViewModel: ObservableObject {
         SettingsModel.shared.useMapboxMap
     }
 
-    static func createViewModel(forConnectionState connectionState: ConnectionState?) -> [StackedTextModel] {
-        [.init(label: "Connection status:", value: " \(connectionState?.asInfo() ?? "-")")]
+    static func createViewModel(forTrackableState trackableState: TrackableState?) -> [StackedTextModel] {
+        [.init(label: "Trackable state:", value: " \(trackableState?.asInfo() ?? "-")")]
     }
 }

--- a/Examples/SubscriberExample/Sources/Screens/Map/Helpers/DescriptionsHelper.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/Helpers/DescriptionsHelper.swift
@@ -45,7 +45,7 @@ enum DescriptionsHelper {
     }
 
     enum AssetState {
-        case connectionState(_: ConnectionState?)
+        case trackableState(_: TrackableState?)
         case subscriberPresence(isPresent: Bool?)
     }
 
@@ -53,20 +53,18 @@ enum DescriptionsHelper {
     enum AssetStateHelper {
         static func getDescriptionAndColor(for state: AssetState) -> (desc: String, color: UIColor) {
             switch state {
-            case .connectionState(let connectionState):
-                if let connectionState {
-                    switch connectionState {
+            case .trackableState(let trackableState):
+                if let trackableState {
+                    switch trackableState {
                     case .online:
                         return ("online", .systemGreen)
                     case .offline:
                         return ("offline", .systemRed)
-                    case .closed:
-                        return ("closed", .systemRed)
                     case .failed:
                         return ("failed", .systemRed)
                     }
                 } else {
-                    return ("The asset connection status is not determined", .black)
+                    return ("The trackable state is not determined", .black)
                 }
             case .subscriberPresence(let isPresent):
                 if let isPresent {

--- a/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
+++ b/Examples/SubscriberExample/Sources/Screens/Map/MapViewController.swift
@@ -79,7 +79,7 @@ class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Tracking \(trackingId)"
-        assetStatusLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .connectionState(nil)).desc
+        assetStatusLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .trackableState(nil)).desc
         publisherPresenceLabel.text = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .subscriberPresence(isPresent: nil)).desc
         setupSubscriber()
         setupMapView()
@@ -326,8 +326,8 @@ extension MapViewController: SubscriberDelegate {
         updateHorizontalAccuracyAnnotation(position: position, type: .raw)
     }
 
-    func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
-        let statusDescAndColor = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .connectionState(status))
+    func subscriber(sender: Subscriber, didChangeTrackableState state: TrackableState) {
+        let statusDescAndColor = DescriptionsHelper.AssetStateHelper.getDescriptionAndColor(for: .trackableState(state))
         assetStatusLabel.textColor = statusDescAndColor.color
         assetStatusLabel.text = statusDescAndColor.desc
     }

--- a/Sources/AblyAssetTrackingCore/Model/TrackableState.swift
+++ b/Sources/AblyAssetTrackingCore/Model/TrackableState.swift
@@ -1,0 +1,38 @@
+/**
+ Indicates Asset connection status (i.e. if courier is publishing their location)
+ */
+public enum TrackableState: Int {
+    // TODO Align this with Android (https://github.com/ably/ably-asset-tracking-swift/issues/625)
+
+    /**
+     Asset is connected to tracking system and we're receiving their position
+     */
+    case online
+
+    /**
+     Asset is not connected
+     */
+    case offline
+
+    /**
+     Connection has failed
+     */
+    case failed
+}
+
+extension TrackableState {
+    var string: String {
+        switch self {
+        case .online:
+            return "online"
+        case .offline:
+            return "offline"
+        case .failed:
+            return "failed"
+        }
+    }
+    // swiftlint:disable:next missing_docs
+    public var description: String {
+        "TrackableState.\(string)"
+    }
+}

--- a/Sources/AblyAssetTrackingInternal/ConnectionState.swift
+++ b/Sources/AblyAssetTrackingInternal/ConnectionState.swift
@@ -1,3 +1,4 @@
+import AblyAssetTrackingCore
 import Foundation
 
 /**

--- a/Sources/AblyAssetTrackingInternal/ConnectionState.swift
+++ b/Sources/AblyAssetTrackingInternal/ConnectionState.swift
@@ -2,17 +2,10 @@ import AblyAssetTrackingCore
 import Foundation
 
 /**
- Indicates Asset connection status (i.e. if courier is publishing their location)
+ The state of connectivity to the Ably service.
  */
 public enum ConnectionState: Int {
-    /**
-     Asset is connected to tracking system and we're receiving their position
-     */
     case online
-
-    /**
-     Asset is not connected
-     */
     case offline
 
     /**

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -13,8 +13,8 @@ class DefaultPublisher: Publisher, PublisherInteractor {
     private let isSendResolutionEnabled: Bool
 
     private var ablyPublisher: AblyPublisher
-    private var enhancedLocationState: TrackableState<EnhancedLocationUpdate>
-    private var rawLocationState: TrackableState<RawLocationUpdate>
+    private var enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate>
+    private var rawLocationState: LocationsPublishingState<RawLocationUpdate>
     private var state: PublisherState = .idle
     private var presenceData: PresenceData
     private var areRawLocationsEnabled: Bool
@@ -60,8 +60,8 @@ class DefaultPublisher: Publisher, PublisherInteractor {
         ablyPublisher: AblyPublisher,
         locationService: LocationService,
         routeProvider: RouteProvider,
-        enhancedLocationState: TrackableState<EnhancedLocationUpdate> = TrackableState(),
-        rawLocationState: TrackableState<RawLocationUpdate> = TrackableState(),
+        enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate> = LocationsPublishingState(),
+        rawLocationState: LocationsPublishingState<RawLocationUpdate> = LocationsPublishingState(),
         areRawLocationsEnabled: Bool = false,
         isSendResolutionEnabled: Bool = true,
         constantLocationEngineResolution: Resolution? = nil,

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
@@ -30,7 +30,7 @@ extension DefaultPublisher {
         case ablyChannelConnectionStateChanged(AblyChannelConnectionStateChangedEvent)
         case delegateError(DelegateErrorEvent)
         case delegateEnhancedLocationChanged(DelegateEnhancedLocationChangedEvent)
-        case delegateTrackableConnectionStateChanged(DelegateTrackableConnectionStateChangedEvent)
+        case delegateTrackableConnectionStateChanged(DelegateTrackableStateChangedEvent)
         case delegateResolutionUpdate(DelegateResolutionUpdateEvent)
 
         struct TrackTrackableEvent {
@@ -143,9 +143,9 @@ extension DefaultPublisher {
             let locationUpdate: EnhancedLocationUpdate
         }
 
-        struct DelegateTrackableConnectionStateChangedEvent {
+        struct DelegateTrackableStateChangedEvent {
             let trackable: Trackable
-            let connectionState: ConnectionState
+            let state: TrackableState
         }
 
         struct DelegateResolutionUpdateEvent {
@@ -157,7 +157,7 @@ extension DefaultPublisher {
     enum DelegateEvent {
         case error(ErrorEvent)
         case enhancedLocationChanged(EnhancedLocationChangedEvent)
-        case trackableConnectionStateChanged(TrackableConnectionStateChangedEvent)
+        case trackableStateChanged(TrackableStateChangedEvent)
         case finishedRecordingLocationHistoryData(FinishedRecordingLocationHistoryDataEvent)
         case finishedRecordingRawMapboxData(FinishedRecordingRawMapboxDataEvent)
         case didUpdateResolution(DidUpdateResolutionEvent)
@@ -171,9 +171,9 @@ extension DefaultPublisher {
             let locationUpdate: EnhancedLocationUpdate
         }
 
-        struct TrackableConnectionStateChangedEvent {
+        struct TrackableStateChangedEvent {
             let trackable: Trackable
-            let connectionState: ConnectionState
+            let state: TrackableState
         }
 
         struct FinishedRecordingLocationHistoryDataEvent {

--- a/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
+++ b/Sources/AblyAssetTrackingPublisher/PublisherDelegate.swift
@@ -25,10 +25,10 @@ public protocol PublisherDelegate: AnyObject {
      
      - Parameters:
         - sender:`Publisher` instance.
-        - state: Most recent trackable's connection state
-        - trackable: Trackable which connection state relates to.
+        - state: Most recent state of the trackable
+        - trackable: Trackable which trackable state relates to.
      */
-    func publisher(sender: Publisher, didChangeConnectionState state: ConnectionState, forTrackable trackable: Trackable)
+    func publisher(sender: Publisher, didChangeState state: TrackableState, forTrackable trackable: Trackable)
 
     /**
      Called when there is a resolution update directly in AblySDK.

--- a/Sources/AblyAssetTrackingPublisher/State/LocationsPublishingState.swift
+++ b/Sources/AblyAssetTrackingPublisher/State/LocationsPublishingState.swift
@@ -1,7 +1,7 @@
 import AblyAssetTrackingCore
 import Foundation
 
-class TrackableState<T: LocationUpdate> {
+class LocationsPublishingState<T: LocationUpdate> {
     let maxRetryCount: Int
     let maxSkippedLocationsSize: Int
 
@@ -17,7 +17,7 @@ class TrackableState<T: LocationUpdate> {
 }
 
 // MARK: - StateRetryable
-extension TrackableState: StateRetryable {
+extension LocationsPublishingState: StateRetryable {
     func shouldRetry(trackableId: String) -> Bool {
         addIfNeeded(trackableId: trackableId)
 
@@ -50,7 +50,7 @@ extension TrackableState: StateRetryable {
 }
 
 // MARK: - StatePendable
-extension TrackableState: StatePendable {
+extension LocationsPublishingState: StatePendable {
     func markMessageAsPending(for trackableId: String) {
         pendingMessages.insert(trackableId)
     }
@@ -66,7 +66,7 @@ extension TrackableState: StatePendable {
 }
 
 // MARK: - StateWaitable
-extension TrackableState: StateWaitable {
+extension LocationsPublishingState: StateWaitable {
     func addToWaiting(locationUpdate: T, for trackableId: String) {
         var locations = waitingLocationUpdates[trackableId] ?? []
         locations.append(locationUpdate)
@@ -86,7 +86,7 @@ extension TrackableState: StateWaitable {
 }
 
 // MARK: - StateSkippable
-extension TrackableState: StateSkippable {
+extension LocationsPublishingState: StateSkippable {
     func addLocation(for trackableId: String, location: T) {
         var locations = skippedLocations[trackableId] ?? []
         locations.append(location)
@@ -107,7 +107,7 @@ extension TrackableState: StateSkippable {
 }
 
 // MARK: - StateRemovable
-extension TrackableState: StateRemovable {
+extension LocationsPublishingState: StateRemovable {
     func remove(trackableId: String) {
         retryCounter.removeValue(forKey: trackableId)
         pendingMessages.remove(trackableId)

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
@@ -56,7 +56,7 @@ extension DefaultSubscriber {
         case delegateRawLocationReceived(DelegateRawLocationReceivedEvent)
         case delegateResolutionReceived(DelegateResolutionReceivedEvent)
         case delegateDesiredIntervalReceived(DelegateDesiredIntervalReceivedEvent)
-        case delegateConnectionStatusChanged(DelegateConnectionStatusChangedEvent)
+        case delegateTrackableStateChanged(DelegateTrackableStateChangedEvent)
         case delegateUpdatedPublisherPresence(DelegateUpdatedPublisherPresenceEvent)
 
         struct DelegateErrorEvent {
@@ -79,8 +79,8 @@ extension DefaultSubscriber {
             let desiredInterval: Double
         }
 
-        struct DelegateConnectionStatusChangedEvent {
-            let status: ConnectionState
+        struct DelegateTrackableStateChangedEvent {
+            let state: TrackableState
         }
 
         struct DelegateUpdatedPublisherPresenceEvent {

--- a/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
+++ b/Sources/AblyAssetTrackingSubscriber/SubscriberDelegate.swift
@@ -46,13 +46,13 @@ public protocol SubscriberDelegate: AnyObject {
     func subscriber(sender: Subscriber, didUpdateDesiredInterval interval: Double)
 
     /**
-     Called when `Subscriber` change connection status
+     Called when `Subscriber` change trackable status
      
      -  Parameters:
         - sender: `Subscriber` instance.
-        - status: Updated connection status.
+        - status: Updated trackable status.
      */
-    func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState)
+    func subscriber(sender: Subscriber, didChangeTrackableState state: TrackableState)
 
     /**
      Called when the `Subscriber` receives updated information about whether the publisher is present.

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisherTests.swift
@@ -18,7 +18,7 @@ class DefaultPublisherTests: XCTestCase {
     var trackable: Trackable!
     var publisher: DefaultPublisher!
     var delegate: MockPublisherDelegate!
-    var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
+    var enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate>!
 
     let logger = InternalLogHandlerMockThreadSafe()
     let waitAsync = WaitAsync()
@@ -35,7 +35,7 @@ class DefaultPublisherTests: XCTestCase {
             destination: LocationCoordinate(latitude: 3.1415, longitude: 2.7182)
         )
         delegate = MockPublisherDelegate()
-        enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
+        enhancedLocationState = LocationsPublishingState<EnhancedLocationUpdate>()
         publisher = DefaultPublisher(
             routingProfile: .driving,
             resolutionPolicyFactory: resolutionPolicyFactory,
@@ -893,10 +893,10 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertNotNil(ablyPublisher.closeCompletion)
     }
 
-    func testDefaultTrackableStateRetry() {
+    func testDefaultLocationsPublishingStateRetry() {
         let trackableId = "trackable_1"
         let otherTrackableId = "trackable_2"
-        let state = TrackableState<EnhancedLocationUpdate>()
+        let state = LocationsPublishingState<EnhancedLocationUpdate>()
 
         /**
          The `shouldRetry` method wraps few functionalities:
@@ -926,11 +926,11 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertEqual(state.getRetryCounter(for: trackableId), 0)
     }
 
-    func testDefaultTrackableStateWaiting() {
+    func testDefaultLocationsPublishingStateWaiting() {
         let trackableId = "trackable_1"
         let locationUpdate = EnhancedLocationUpdate(location: Location(coordinate: LocationCoordinate(latitude: 1, longitude: 1)))
         let anotherLocationUpdate = EnhancedLocationUpdate(location: Location(coordinate: LocationCoordinate(latitude: 2, longitude: 2)))
-        let state = TrackableState<EnhancedLocationUpdate>()
+        let state = LocationsPublishingState<EnhancedLocationUpdate>()
 
         /**
          Add two location updates
@@ -958,9 +958,9 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertNil(state.nextWaitingLocation(for: trackableId))
     }
 
-    func testDefaultTrackableStatePending() {
+    func testDefaultLocationsPublishingStatePending() {
         let trackableId = "trackable_1"
-        let state = TrackableState<EnhancedLocationUpdate>()
+        let state = LocationsPublishingState<EnhancedLocationUpdate>()
 
         XCTAssertFalse(state.hasPendingMessage(for: trackableId))
 
@@ -973,11 +973,11 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertFalse(state.hasPendingMessage(for: trackableId))
     }
 
-    func testDefaultTrackableStateRemove() {
+    func testDefaultLocationsPublishingStateRemove() {
         let trackableId = "trackable_1"
         let trackableId2 = "trackable_2"
         let locationUpdate = EnhancedLocationUpdate(location: Location(coordinate: LocationCoordinate(latitude: 1, longitude: 1)))
-        let state = TrackableState<EnhancedLocationUpdate>()
+        let state = LocationsPublishingState<EnhancedLocationUpdate>()
 
         state.markMessageAsPending(for: trackableId)
         state.markMessageAsPending(for: trackableId2)
@@ -1095,8 +1095,8 @@ class DefaultPublisherTests: XCTestCase {
         XCTAssertEqual(state.locationsList(for: trackableId).last!.location, overflowLocation)
     }
 
-    private func createSkippedLocationState(with data: [String: [Location]] = [:], capacity: Int = 10) -> TrackableState<EnhancedLocationUpdate> {
-        let state = TrackableState<EnhancedLocationUpdate>(maxSkippedLocationsSize: capacity)
+    private func createSkippedLocationState(with data: [String: [Location]] = [:], capacity: Int = 10) -> LocationsPublishingState<EnhancedLocationUpdate> {
+        let state = LocationsPublishingState<EnhancedLocationUpdate>(maxSkippedLocationsSize: capacity)
         for (trackableId, locations) in data {
             locations.map(EnhancedLocationUpdate.init).forEach { enhancedLocationUpdate in
                 state.addLocation(for: trackableId, location: enhancedLocationUpdate)

--- a/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
+++ b/Tests/PublisherTests/DefaultPublisher/DefaultPublisher_LocationServiceTests.swift
@@ -19,8 +19,8 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
     var publisher: DefaultPublisher!
     var delegate: MockPublisherDelegate!
     var waitAsync: WaitAsync!
-    var enhancedLocationState: TrackableState<EnhancedLocationUpdate>!
-    var rawLocationState: TrackableState<RawLocationUpdate>!
+    var enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate>!
+    var rawLocationState: LocationsPublishingState<RawLocationUpdate>!
     var logger: InternalLogHandlerMockThreadSafe!
 
     override func setUpWithError() throws {
@@ -31,8 +31,8 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         resolutionPolicyFactory = MockResolutionPolicyFactory()
         delegate = MockPublisherDelegate()
         waitAsync = WaitAsync()
-        enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
-        rawLocationState = TrackableState<RawLocationUpdate>()
+        enhancedLocationState = LocationsPublishingState<EnhancedLocationUpdate>()
+        rawLocationState = LocationsPublishingState<RawLocationUpdate>()
         logger = InternalLogHandlerMockThreadSafe()
 
         trackable = Trackable(
@@ -197,7 +197,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let location = Location(coordinate: LocationCoordinate(latitude: 1, longitude: 1))
         let locationUpdate = EnhancedLocationUpdate(location: location)
         let trackable = Trackable(id: "Trackable_1")
-        let trackableState = TrackableState<EnhancedLocationUpdate>()
+        let enhancedLocationsPublishingState = LocationsPublishingState<EnhancedLocationUpdate>()
         let ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish)
         let publisher = PublisherHelper.createPublisher(ablyPublisher: ablyPublisher)
 
@@ -209,7 +209,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
             publisher: publisher,
             locationUpdate: locationUpdate,
             trackable: trackable,
-            enhancedLocationState: trackableState,
+            enhancedLocationState: enhancedLocationsPublishingState,
             resultPolicy: .retry
         )
 
@@ -223,7 +223,7 @@ class DefaultPublisher_LocationServiceTests: XCTestCase {
         let initialLocation = Location(coordinate: LocationCoordinate(latitude: 1, longitude: 1))
         var locationUpdate = EnhancedLocationUpdate(location: initialLocation)
         let trackable = Trackable(id: "Trackable_2")
-        let enhancedLocationState = TrackableState<EnhancedLocationUpdate>()
+        let enhancedLocationState = LocationsPublishingState<EnhancedLocationUpdate>()
         let ablyPublisher = MockAblyPublisher(configuration: configuration, mode: .publish)
         let delegate = MockPublisherDelegate()
         let publisher = PublisherHelper.createPublisher(

--- a/Tests/PublisherTests/Helpers/PublisherHelper.swift
+++ b/Tests/PublisherTests/Helpers/PublisherHelper.swift
@@ -27,7 +27,7 @@ class PublisherHelper {
         locationUpdate: EnhancedLocationUpdate,
         trackable: Trackable,
         locationService: LocationService = MockLocationService(),
-        enhancedLocationState: TrackableState<EnhancedLocationUpdate>,
+        enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate>,
         resultPolicy: SendLocationResultPolicy = .success,
         error: ErrorInformation = ErrorInformation(type: .commonError(errorMessage: "Failure"))
     ) {
@@ -95,7 +95,7 @@ class PublisherHelper {
         resolutionPolicyFactory: ResolutionPolicyFactory = MockResolutionPolicyFactory(),
         locationService: LocationService = MockLocationService(),
         routeProvider: RouteProvider = MockRouteProvider(),
-        enhancedLocationState: TrackableState<EnhancedLocationUpdate> = TrackableState<EnhancedLocationUpdate>(),
+        enhancedLocationState: LocationsPublishingState<EnhancedLocationUpdate> = LocationsPublishingState<EnhancedLocationUpdate>(),
         logHandler: InternalLogHandlerMockThreadSafe = InternalLogHandlerMockThreadSafe()
     ) -> DefaultPublisher {
         DefaultPublisher(

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -361,8 +361,8 @@ class DefaultSubscriberTests: XCTestCase {
             delegateDidFailWithErrorCalledExpectation.fulfill()
         }
 
-        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeAssetConnectionStatus")
-        delegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, status in
+        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeTrackableState")
+        delegate.subscriberSenderDidChangeTrackableStateClosure = { _, status in
             XCTAssertEqual(status, .failed)
             delegateDidChangeAssetConnectionStatusExpectation.fulfill()
         }
@@ -383,8 +383,8 @@ class DefaultSubscriberTests: XCTestCase {
         let delegate = SubscriberDelegateMock()
         subscriber.delegate = delegate
 
-        let failedStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeAssetConnectionStatus with failed status")
-        delegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, status in
+        let failedStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeTrackableState with failed status")
+        delegate.subscriberSenderDidChangeTrackableStateClosure = { _, status in
             XCTAssertEqual(status, .failed)
             failedStatusExpectation.fulfill()
         }
@@ -393,7 +393,7 @@ class DefaultSubscriberTests: XCTestCase {
 
         waitForExpectations(timeout: 10)
 
-        delegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, _ in
+        delegate.subscriberSenderDidChangeTrackableStateClosure = { _, _ in
             XCTFail("Subscriber’s delegate received a connection status update")
         }
 

--- a/Tests/SubscriberTests/WorkerQueue/SubscriberWorkerQueuePropertiesTests.swift
+++ b/Tests/SubscriberTests/WorkerQueue/SubscriberWorkerQueuePropertiesTests.swift
@@ -137,10 +137,10 @@ class SubscriberWorkerQueuePropertiesTests: XCTestCase {
     func test_subscriberProperties_notifyTrackableStateUpdated_calls_didChangeAssetConnectionStatus_delegate() {
         subscriber.delegate = subscriberDelegate
 
-        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber's delegate receives didChangeAssetConnectionStatus")
-        subscriberDelegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, connectionState  in
-            XCTAssertEqual(connectionState, .online)
-            delegateDidChangeAssetConnectionStatusExpectation.fulfill()
+        let delegateDidChangeTrackableStateExpectation = expectation(description: "Subscriber's delegate receives didChangeTrackableState")
+        subscriberDelegate.subscriberSenderDidChangeTrackableStateClosure = { _, trackableState  in
+            XCTAssertEqual(trackableState, .online)
+            delegateDidChangeTrackableStateExpectation.fulfill()
         }
 
         subscriberProperties.notifyTrackableStateUpdated(trackableState: .online, logHandler: logger)
@@ -190,10 +190,10 @@ class SubscriberWorkerQueuePropertiesTests: XCTestCase {
     }
 
     func test_subscriberProperties_delegatesEvents() {
-        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeAssetConnectionStatus")
-        subscriberDelegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, status in
+        let delegateDidChangeTrackableStateExpectation = expectation(description: "Subscriber’s delegate receives didChangeTrackableState")
+        subscriberDelegate.subscriberSenderDidChangeTrackableStateClosure = { _, status in
             XCTAssertEqual(status, .online)
-            delegateDidChangeAssetConnectionStatusExpectation.fulfill()
+            delegateDidChangeTrackableStateExpectation.fulfill()
         }
 
         let delegateDidUpdatePresence = expectation(description: "Subscriber's delegate receives didUpdatePublisherPresence")

--- a/Tests/Support/AblyAssetTrackingPublisherTesting/Mocks/MockPublisherDelegate.swift
+++ b/Tests/Support/AblyAssetTrackingPublisherTesting/Mocks/MockPublisherDelegate.swift
@@ -28,17 +28,17 @@ public class MockPublisherDelegate: PublisherDelegate {
         publisherDidUpdateEnhancedLocationCallback?()
     }
 
-    public var publisherDidChangeTrackableConnectionStateCalled = false
-    public var publisherDidChangeTrackableConnectionStateParamSender: Publisher?
-    public var publisherDidChangeTrackableConnectionStateParamState: ConnectionState?
-    public var publisherDidChangeTrackableConnectionStateParamTrackable: Trackable?
-    public var publisherDidChangeTrackableConnectionStateCallback: (() -> Void)?
-    public func publisher(sender: Publisher, didChangeConnectionState state: ConnectionState, forTrackable trackable: Trackable) {
-        publisherDidChangeTrackableConnectionStateCalled = true
-        publisherDidChangeTrackableConnectionStateParamSender = sender
-        publisherDidChangeTrackableConnectionStateParamState = state
-        publisherDidChangeTrackableConnectionStateParamTrackable = trackable
-        publisherDidChangeTrackableConnectionStateCallback?()
+    public var publisherDidChangeTrackableStateCalled = false
+    public var publisherDidChangeTrackableStateParamSender: Publisher?
+    public var publisherDidChangeTrackableStateParamState: TrackableState?
+    public var publisherDidChangeTrackableStateParamTrackable: Trackable?
+    public var publisherDidChangeTrackableStateCallback: (() -> Void)?
+    public func publisher(sender: Publisher, didChangeState state: TrackableState, forTrackable trackable: Trackable) {
+        publisherDidChangeTrackableStateCalled = true
+        publisherDidChangeTrackableStateParamSender = sender
+        publisherDidChangeTrackableStateParamState = state
+        publisherDidChangeTrackableStateParamTrackable = trackable
+        publisherDidChangeTrackableStateCallback?()
     }
 
     public var publisherDidUpdateResolutionCalled = false

--- a/Tests/Support/AblyAssetTrackingSubscriberTesting/Mocks/GeneratedMocks.swift
+++ b/Tests/Support/AblyAssetTrackingSubscriberTesting/Mocks/GeneratedMocks.swift
@@ -166,19 +166,19 @@ public class SubscriberDelegateMock: SubscriberDelegate {
 
     //MARK: - subscriber
 
-    public var subscriberSenderDidChangeAssetConnectionStatusCallsCount = 0
-    public var subscriberSenderDidChangeAssetConnectionStatusCalled: Bool {
-        return subscriberSenderDidChangeAssetConnectionStatusCallsCount > 0
+    public var subscriberSenderDidChangeTrackableStateCallsCount = 0
+    public var subscriberSenderDidChangeTrackableStateCalled: Bool {
+        return subscriberSenderDidChangeTrackableStateCallsCount > 0
     }
-    public var subscriberSenderDidChangeAssetConnectionStatusReceivedArguments: (sender: Subscriber, status: ConnectionState)?
-    public var subscriberSenderDidChangeAssetConnectionStatusReceivedInvocations: [(sender: Subscriber, status: ConnectionState)] = []
-    public var subscriberSenderDidChangeAssetConnectionStatusClosure: ((Subscriber, ConnectionState) -> Void)?
+    public var subscriberSenderDidChangeTrackableStateReceivedArguments: (sender: Subscriber, state: TrackableState)?
+    public var subscriberSenderDidChangeTrackableStateReceivedInvocations: [(sender: Subscriber, state: TrackableState)] = []
+    public var subscriberSenderDidChangeTrackableStateClosure: ((Subscriber, TrackableState) -> Void)?
 
-    public func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
-        subscriberSenderDidChangeAssetConnectionStatusCallsCount += 1
-        subscriberSenderDidChangeAssetConnectionStatusReceivedArguments = (sender: sender, status: status)
-        subscriberSenderDidChangeAssetConnectionStatusReceivedInvocations.append((sender: sender, status: status))
-        subscriberSenderDidChangeAssetConnectionStatusClosure?(sender, status)
+    public func subscriber(sender: Subscriber, didChangeTrackableState state: TrackableState) {
+        subscriberSenderDidChangeTrackableStateCallsCount += 1
+        subscriberSenderDidChangeTrackableStateReceivedArguments = (sender: sender, state: state)
+        subscriberSenderDidChangeTrackableStateReceivedInvocations.append((sender: sender, state: state))
+        subscriberSenderDidChangeTrackableStateClosure?(sender, state)
     }
 
     //MARK: - subscriber

--- a/Tests/SystemTests/ChannelModesTests.swift
+++ b/Tests/SystemTests/ChannelModesTests.swift
@@ -165,7 +165,7 @@ class ChannelModesTests: XCTestCase {
 extension ChannelModesTests: SubscriberDelegate {
     func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didFailWithError error: ErrorInformation) {}
 
-    func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {}
+    func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didChangeTrackableState state: TrackableState) {}
 
     func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didUpdateEnhancedLocation locationUpdate: LocationUpdate) {
         didUpdateEnhancedLocationExpectation.fulfill()

--- a/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/CombineSubscriberDelegate.swift
+++ b/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/CombineSubscriberDelegate.swift
@@ -13,13 +13,13 @@ extension SubscriberNetworkConnectivityTests {
     class CombineSubscriberDelegate: SubscriberDelegate {
         private let logHandler: InternalLogHandler
 
-        /// Publishes the connection status values received by ``SubscriberDelegate.subscriber(sender:,didChangeAssetConnectionStatus:)``.
+        /// Publishes the connection status values received by ``SubscriberDelegate.subscriber(sender:,didChangeTrackableState:)``.
         ///
         /// This is meant to mimic Android’s `_trackableStates = MutableStateFlow(TrackableState.Offline())`.
         ///
         /// This publisher sends the latest received value to each new subscriber, to mimic the behaviour of a Kotlin `StateFlow`. Unlike a `StateFlow`, however, this publisher does not publish an initial value.
-        let trackableStates: AnyPublisher<ConnectionState, Never>
-        private let trackableStatesSubject = CurrentValueSubject<ConnectionState?, Never>(nil)
+        let trackableStates: AnyPublisher<TrackableState, Never>
+        private let trackableStatesSubject = CurrentValueSubject<TrackableState?, Never>(nil)
 
         /// Publishes the resolution values received by ``SubscriberDelegate.subscriber(sender:,didUpdateResolution:)``.
         ///
@@ -56,10 +56,10 @@ extension SubscriberNetworkConnectivityTests {
 
         // MARK: SubscriberDelegate
 
-        func subscriber(sender: Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
-            logHandler.debug(message: "Delegate received subscriber(sender:,didChangeAssetConnectionStatus:) - status \(status)", error: nil)
-            trackableStatesSubject.value = status
-            logHandler.debug(message: "Sent status \(status) to _trackableStates", error: nil)
+        func subscriber(sender: Subscriber, didChangeTrackableState state: TrackableState) {
+            logHandler.debug(message: "Delegate received subscriber(sender:,didChangeTrackableState:) - status \(state)", error: nil)
+            trackableStatesSubject.value = state
+            logHandler.debug(message: "Sent state \(state) to _trackableStates", error: nil)
         }
 
         func subscriber(sender: Subscriber, didUpdateResolution resolution: Resolution) {

--- a/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/CombineSubscriberDelegateTests.swift
+++ b/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/CombineSubscriberDelegateTests.swift
@@ -15,9 +15,9 @@ class CombineSubscriberDelegateTests: XCTestCase {
         let subscriber = SubscriberMock()
 
         // Given...
-        // ...that the object under test has received an invocation of `subscriber(sender:,didChangeAssetConnectionStatus:)`
+        // ...that the object under test has received an invocation of `subscriber(sender:,didChangeTrackableState:)`
 
-        combineSubscriberDelegate.subscriber(sender: subscriber, didChangeAssetConnectionStatus: .online)
+        combineSubscriberDelegate.subscriber(sender: subscriber, didChangeTrackableState: .online)
 
         // When...
 

--- a/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/SubscriberMonitor.swift
+++ b/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/SubscriberMonitor.swift
@@ -28,8 +28,8 @@ extension SubscriberNetworkConnectivityTests {
         private let subscriberClientID: String
         private let label: String
         private let trackableID: String
-        private let expectedState: ConnectionState
-        private let failureStates: Set<ConnectionState>
+        private let expectedState: TrackableState
+        private let failureStates: Set<TrackableState>
         private let expectedSubscriberPresence: Bool?
         private let expectedPublisherPresence: Bool
         private let expectedLocation: Location?
@@ -49,7 +49,7 @@ extension SubscriberNetworkConnectivityTests {
             }
         }
 
-        init(sharedState: SharedState, logHandler: InternalLogHandler, subscriber: Subscriber, subscriberClientID: String, label: String, trackableID: String, expectedState: ConnectionState, failureStates: Set<ConnectionState>, expectedSubscriberPresence: Bool?, expectedPublisherPresence: Bool, expectedLocation: Location?, expectedPublisherResolution: Resolution?, expectedSubscriberResolution: Resolution?, timeout: TimeInterval, subscriberResolutionPreferences: AnyPublisher<Resolution, Never>) {
+        init(sharedState: SharedState, logHandler: InternalLogHandler, subscriber: Subscriber, subscriberClientID: String, label: String, trackableID: String, expectedState: TrackableState, failureStates: Set<TrackableState>, expectedSubscriberPresence: Bool?, expectedPublisherPresence: Bool, expectedLocation: Location?, expectedPublisherResolution: Resolution?, expectedSubscriberResolution: Resolution?, timeout: TimeInterval, subscriberResolutionPreferences: AnyPublisher<Resolution, Never>) {
             self.sharedState = sharedState
             self.logHandler = logHandler.addingSubsystem(.named("SubscriberMonitor(\(label))"))
             self.subscriber = subscriber
@@ -214,9 +214,9 @@ extension SubscriberNetworkConnectivityTests {
         }
 
         /**
-         * Maps received `ConnectionState` to a success/fail/ignore outcome for this test.
+         * Maps received `TrackableState` to a success/fail/ignore outcome for this test.
          */
-        private static func receive(_ state: ConnectionState, failureStates: Set<ConnectionState>, expectedState: ConnectionState, logHandler: InternalLogHandler) -> Bool? {
+        private static func receive(_ state: TrackableState, failureStates: Set<TrackableState>, expectedState: TrackableState, logHandler: InternalLogHandler) -> Bool? {
             if failureStates.contains(state) {
                 logHandler.logMessage(level: .error, message: "(FAIL) Got state \(state)", error: nil)
                 return false

--- a/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/SubscriberMonitorFactory.swift
+++ b/Tests/SystemTests/NetworkConnectivityTests/Subscriber/Helper/SubscriberMonitorFactory.swift
@@ -36,7 +36,7 @@ extension SubscriberNetworkConnectivityTests {
             publisherDisconnected: Bool = false,
             subscriberResolution: Resolution? = nil
         ) -> SubscriberMonitor {
-            let expectedState: ConnectionState
+            let expectedState: TrackableState
             switch faultType {
             case .fatal:
                 expectedState = .failed
@@ -48,7 +48,7 @@ extension SubscriberNetworkConnectivityTests {
                 expectedState = .offline
             }
 
-            let failureStates: Set<ConnectionState>
+            let failureStates: Set<TrackableState>
             switch faultType {
             case .fatal:
                 failureStates = [.offline]
@@ -116,7 +116,7 @@ extension SubscriberNetworkConnectivityTests {
             publisherDisconnected: Bool = false,
             subscriberResolution: Resolution? = nil
         ) -> SubscriberMonitor {
-            let expectedState: ConnectionState
+            let expectedState: TrackableState
             switch faultType {
             case .fatal:
                 expectedState = .failed
@@ -124,7 +124,7 @@ extension SubscriberNetworkConnectivityTests {
                 expectedState = .offline
             }
 
-            let failureStates: Set<ConnectionState>
+            let failureStates: Set<TrackableState>
             switch faultType {
             case .fatal:
                 failureStates = [.online, .offline]
@@ -188,7 +188,7 @@ extension SubscriberNetworkConnectivityTests {
             expectedPublisherPresence: Bool = true,
             subscriberResolution: Resolution? = nil
         ) -> SubscriberMonitor {
-            let expectedState: ConnectionState
+            let expectedState: TrackableState
             if !expectedPublisherPresence {
                 expectedState = .offline
             } else {
@@ -200,7 +200,7 @@ extension SubscriberNetworkConnectivityTests {
                 }
             }
 
-            let failureStates: Set<ConnectionState>
+            let failureStates: Set<TrackableState>
             switch faultType {
             case .fatal:
                 failureStates = [.offline, .online]

--- a/Tests/SystemTests/PublisherSubscriberSystemTests.swift
+++ b/Tests/SystemTests/PublisherSubscriberSystemTests.swift
@@ -18,8 +18,8 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
     private var locationChangeTimer: Timer!
     private var locationsData: Locations!
 
-    private let didChangeAssetConnectionStatusOnlineExpectation = XCTestExpectation(description: "Asset Connection Status Did Change To Online")
-    private let didChangeAssetConnectionStatusOfflineExpectation = XCTestExpectation(description: "Asset Connection Status Did Change To Offline")
+    private let didChangeTrackableStateOnlineExpectation = XCTestExpectation(description: "Trackable State Did Change To Online")
+    private let didChangeTrackableStateOfflineExpectation = XCTestExpectation(description: "Trackable State Did Change To Offline")
     private let didUpdateEnhancedLocationExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Enhanced Locations")
     private let didUpdateRawLocationExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Raw Locations")
     private let didUpdateResolutionExpectation = XCTestExpectation(description: "Subscriber Did Finish Updating Resolution")
@@ -133,10 +133,10 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             .start { _ in }!
 
         delay(5)
-        didChangeAssetConnectionStatusOnlineExpectation.isInverted = true
-        didChangeAssetConnectionStatusOfflineExpectation.isInverted = true
+        didChangeTrackableStateOnlineExpectation.isInverted = true
+        didChangeTrackableStateOfflineExpectation.isInverted = true
         wait(for: [
-            didChangeAssetConnectionStatusOnlineExpectation, didChangeAssetConnectionStatusOfflineExpectation
+            didChangeTrackableStateOnlineExpectation, didChangeTrackableStateOfflineExpectation
         ], timeout: 0.0)
 
         subscriber.stop { _ in }
@@ -198,7 +198,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
             .trackingId(trackableId)
             .start { _ in }!
 
-        wait(for: [didChangeAssetConnectionStatusOnlineExpectation], timeout: 5.0)
+        wait(for: [didChangeTrackableStateOnlineExpectation], timeout: 5.0)
 
         let stopPublisherExpectation = self.expectation(description: "Publisher did call stop completion closure")
         publisher.stop { _ in
@@ -206,7 +206,7 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
         }
         wait(for: [stopPublisherExpectation], timeout: 5)
 
-        wait(for: [didChangeAssetConnectionStatusOfflineExpectation], timeout: 5.0)
+        wait(for: [didChangeTrackableStateOfflineExpectation], timeout: 5.0)
 
         subscriber.stop { _ in }
     }
@@ -221,14 +221,12 @@ class PublisherAndSubscriberSystemTests: XCTestCase {
 extension PublisherAndSubscriberSystemTests: SubscriberDelegate {
     func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didFailWithError error: ErrorInformation) {}
 
-    func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didChangeAssetConnectionStatus status: ConnectionState) {
-        switch status {
+    func subscriber(sender: AblyAssetTrackingSubscriber.Subscriber, didChangeTrackableState state: TrackableState) {
+        switch state {
         case .online:
-            didChangeAssetConnectionStatusOnlineExpectation.fulfill()
+            didChangeTrackableStateOnlineExpectation.fulfill()
         case .offline:
-            didChangeAssetConnectionStatusOfflineExpectation.fulfill()
-        case .closed:
-            ()
+            didChangeTrackableStateOfflineExpectation.fulfill()
         case .failed:
             ()
         }

--- a/Tests/SystemTests/SubscriberSystemTests.swift
+++ b/Tests/SystemTests/SubscriberSystemTests.swift
@@ -31,8 +31,8 @@ class SubscriberSystemTests: XCTestCase {
             delegateDidFailWithErrorCalledExpectation.fulfill()
         }
 
-        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeAssetConnectionStatus")
-        delegate.subscriberSenderDidChangeAssetConnectionStatusClosure = { _, status in
+        let delegateDidChangeAssetConnectionStatusExpectation = expectation(description: "Subscriber’s delegate receives didChangeTrackableState")
+        delegate.subscriberSenderDidChangeTrackableStateClosure = { _, status in
             XCTAssertEqual(status, .failed)
             delegateDidChangeAssetConnectionStatusExpectation.fulfill()
         }


### PR DESCRIPTION
**Note: This is based on top of #629, and shouldn’t be merged to `main` until that one is.**

This changes `TrackableState` to be a public type which is used to describe the state of a trackable, and `ConnectionState` to be an internal type which is used to describe the state of the Ably connection. This makes things consistent with Android. See commit messages for more details.

Closes #624.