### PR TITLE
Rename `didReceivePresenceUpdate` to `didReceivePresenceMessage`

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblyPublisher.swift
@@ -30,7 +30,7 @@ public protocol AblyPublisherDelegate: AnyObject {
     func ablyPublisher(_ sender: AblyPublisher, didFailWithError error: ErrorInformation)
 
     /**
-     Tells the delegate that channel presence data was changed.
+     Tells the delegate that a presence message was received on a channel.
      
      - Parameter sender:        The `AblyPublisher` object which is delegating the change.
      - Parameter presence:      The `PresenceMessage` object affected by the change.
@@ -40,7 +40,7 @@ public protocol AblyPublisherDelegate: AnyObject {
      */
     func ablyPublisher(
         _ sender: AblyPublisher,
-        didReceivePresenceUpdate presence: PresenceMessage,
+        didReceivePresenceMessage presence: PresenceMessage,
         forTrackable trackable: Trackable,
         presenceData: PresenceData,
         clientId: String

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/AblySubscriber.swift
@@ -21,12 +21,12 @@ public protocol AblySubscriberDelegate: AnyObject {
     func ablySubscriber(_ sender: AblySubscriber, didChangeChannelConnectionState state: ConnectionState)
 
     /**
-     Tells the delegate that channel presence was changed.
+     Tells the delegate that a presence message was received on the channel.
      
      - Parameter sender:        The `AblySubscriber` object which is delegating the change.
      - Parameter presence:      The `PresenceMessage` object affected by the change.
      */
-    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: PresenceMessage)
+    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceMessage presence: PresenceMessage)
 
     /**
      Tells the delegate that an error occurred.

--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -315,7 +315,7 @@ public class DefaultAbly: AblyCommon {
         )
 
         // AblySubscriber delegate
-        self.subscriberDelegate?.ablySubscriber(self, didReceivePresenceUpdate: presence)
+        self.subscriberDelegate?.ablySubscriber(self, didReceivePresenceMessage: presence)
         self.subscriberDelegate?.ablySubscriber(self, didChangeChannelConnectionState: presence.action.toConnectionState())
 
         // Deleagate `Publisher` resolution if present in PresenceData
@@ -326,7 +326,7 @@ public class DefaultAbly: AblyCommon {
         // AblyPublisher delegate
         self.publisherDelegate?.ablyPublisher(
             self,
-            didReceivePresenceUpdate: presence,
+            didReceivePresenceMessage: presence,
             forTrackable: trackable,
             presenceData: data,
             clientId: clientId

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisher.swift
@@ -184,8 +184,8 @@ extension DefaultPublisher {
                 self?.performRefreshResolutionPolicyEvent(event)
             case .changeLocationEngineResolution(let event):
                 self?.performChangeLocationEngineResolutionEvent(event)
-            case .presenceUpdate(let event):
-                self?.performPresenceUpdateEvent(event)
+            case .presenceMessage(let event):
+                self?.performPresenceMessageEvent(event)
             case .clearRemovedTrackableMetadata(let event):
                 self?.performClearRemovedTrackableMetadataEvent(event)
             case .setDestinationSuccess(let event):
@@ -847,9 +847,9 @@ extension DefaultPublisher {
     }
 
     // MARK: Subscribers handling
-    private func performPresenceUpdateEvent(_ event: Event.PresenceUpdateEvent) {
+    private func performPresenceMessageEvent(_ event: Event.PresenceMessageEvent) {
         guard !state.isStoppingOrStopped else {
-            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform PresenceUpdateEvent. Publisher is either stopped or stopping.")))
+            logHandler?.error(error: ErrorInformation(type: .publisherError(errorMessage: "Cannot perform PresenceMessageEvent. Publisher is either stopped or stopping.")))
             return
         }
 
@@ -980,13 +980,13 @@ extension DefaultPublisher: AblyPublisherDelegate {
 
     func ablyPublisher(
         _ sender: AblyPublisher,
-        didReceivePresenceUpdate presence: PresenceMessage,
+        didReceivePresenceMessage presence: PresenceMessage,
         forTrackable trackable: Trackable,
         presenceData: PresenceData,
         clientId: String
     ) {
-        logHandler?.debug(message: "publisherService.didReceivePresenceUpdate. Presence: \(presence), Trackable: \(trackable)", error: nil)
-        enqueue(event: .presenceUpdate(.init(trackable: trackable, presence: presence, presenceData: presenceData, clientId: clientId)))
+        logHandler?.debug(message: "publisherService.didReceivePresenceMessage. Presence: \(presence), Trackable: \(trackable)", error: nil)
+        enqueue(event: .presenceMessage(.init(trackable: trackable, presence: presence, presenceData: presenceData, clientId: clientId)))
     }
 }
 

--- a/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
+++ b/Sources/AblyAssetTrackingPublisher/DefaultPublisherEvents.swift
@@ -23,7 +23,7 @@ extension DefaultPublisher {
         case refreshResolutionPolicy(RefreshResolutionPolicyEvent)
         case changeLocationEngineResolution(ChangeLocationEngineResolutionEvent)
         case changeRoutingProfile(ChangeRoutingProfileEvent)
-        case presenceUpdate(PresenceUpdateEvent)
+        case presenceMessage(PresenceMessageEvent)
         case stop(StopEvent)
         case ablyConnectionClosed(AblyConnectionClosedEvent)
         case ablyClientConnectionStateChanged(AblyClientConnectionStateChangedEvent)
@@ -111,7 +111,7 @@ extension DefaultPublisher {
             let completion: Callback<Void>
         }
 
-        struct PresenceUpdateEvent {
+        struct PresenceMessageEvent {
             let trackable: Trackable
             let presence: PresenceMessage
             let presenceData: PresenceData

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriber.swift
@@ -107,8 +107,8 @@ extension DefaultSubscriber {
                 self?.performClientConnectionChanged(event)
             case .ablyChannelConnectionStateChanged(let event):
                 self?.performChannelConnectionChanged(event)
-            case .presenceUpdate(let event):
-                self?.performPresenceUpdated(event)
+            case .presenceMessageReceived(let event):
+                self?.performPresenceMessageReceived(event)
             case .ablyError(let event):
                 self?.performAblyError(event)
             }
@@ -202,7 +202,7 @@ extension DefaultSubscriber {
         }
     }
 
-    private func performPresenceUpdated(_ event: Event.PresenceUpdateEvent) {
+    private func performPresenceMessageReceived(_ event: Event.PresenceMessageReceivedEvent) {
         guard event.presence.type == .publisher else {
             return
         }
@@ -320,9 +320,9 @@ extension DefaultSubscriber {
 }
 
 extension DefaultSubscriber: AblySubscriberDelegate {
-    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: PresenceMessage) {
-        logHandler?.debug(message: "ablySubscriber.didReceivePresenceUpdate. Presence: \(presence)", error: nil)
-        enqueue(event: .presenceUpdate(.init(presence: presence)))
+    func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceMessage presence: PresenceMessage) {
+        logHandler?.debug(message: "ablySubscriber.didReceivePresenceMessage. Presence: \(presence)", error: nil)
+        enqueue(event: .presenceMessageReceived(.init(presence: presence)))
     }
 
     func ablySubscriber(_ sender: AblySubscriber, didChangeClientConnectionState state: ConnectionState) {

--- a/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
+++ b/Sources/AblyAssetTrackingSubscriber/DefaultSubscriberEvents.swift
@@ -8,7 +8,7 @@ extension DefaultSubscriber {
         case start(StartEvent)
         case stop(StopEvent)
         case changeResolution(ChangeResolutionEvent)
-        case presenceUpdate(PresenceUpdateEvent)
+        case presenceMessageReceived(PresenceMessageReceivedEvent)
         case ablyConnectionClosed(AblyConnectionClosedEvent)
         case ablyClientConnectionStateChanged(AblyClientConnectionStateChangedEvent)
         case ablyChannelConnectionStateChanged(AblyChannelConnectionStateChangedEvent)
@@ -27,7 +27,7 @@ extension DefaultSubscriber {
             let completion: Callback<Void>
         }
 
-        struct PresenceUpdateEvent {
+        struct PresenceMessageReceivedEvent {
             let presence: PresenceMessage
         }
 

--- a/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
+++ b/Tests/SubscriberTests/DefaultSubscriber/DefaultSubscriberTests.swift
@@ -429,7 +429,7 @@ class DefaultSubscriberTests: XCTestCase {
             delegateDidFailWithErrorCalledExpectation.fulfill()
         }
 
-        ablySubscriber.subscriberDelegate?.ablySubscriber(ablySubscriber, didReceivePresenceUpdate: .init(action: presenceAction, type: .publisher))
+        ablySubscriber.subscriberDelegate?.ablySubscriber(ablySubscriber, didReceivePresenceMessage: .init(action: presenceAction, type: .publisher))
 
         waitForExpectations(timeout: 10)
     }

--- a/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/GeneratedMocks.swift
+++ b/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/GeneratedMocks.swift
@@ -231,7 +231,6 @@ public class AblySDKRealtimeChannelMock: AblySDKRealtimeChannel {
     public var onCalled: Bool {
         return onCallsCount > 0
     }
-    
     public var onReceivedCallback: ((ARTChannelStateChange) -> Void)?
     public var onReceivedInvocations: [((ARTChannelStateChange) -> Void)] = []
     public var onReturnValue: ARTEventListener!
@@ -491,19 +490,19 @@ public class AblySubscriberDelegateMock: AblySubscriberDelegate {
 
     //MARK: - ablySubscriber
 
-    public var ablySubscriberDidReceivePresenceUpdateCallsCount = 0
-    public var ablySubscriberDidReceivePresenceUpdateCalled: Bool {
-        return ablySubscriberDidReceivePresenceUpdateCallsCount > 0
+    public var ablySubscriberDidReceivePresenceMessageCallsCount = 0
+    public var ablySubscriberDidReceivePresenceMessageCalled: Bool {
+        return ablySubscriberDidReceivePresenceMessageCallsCount > 0
     }
-    public var ablySubscriberDidReceivePresenceUpdateReceivedArguments: (sender: AblySubscriber, presence: PresenceMessage)?
-    public var ablySubscriberDidReceivePresenceUpdateReceivedInvocations: [(sender: AblySubscriber, presence: PresenceMessage)] = []
-    public var ablySubscriberDidReceivePresenceUpdateClosure: ((AblySubscriber, PresenceMessage) -> Void)?
+    public var ablySubscriberDidReceivePresenceMessageReceivedArguments: (sender: AblySubscriber, presence: PresenceMessage)?
+    public var ablySubscriberDidReceivePresenceMessageReceivedInvocations: [(sender: AblySubscriber, presence: PresenceMessage)] = []
+    public var ablySubscriberDidReceivePresenceMessageClosure: ((AblySubscriber, PresenceMessage) -> Void)?
 
-    public func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceUpdate presence: PresenceMessage) {
-        ablySubscriberDidReceivePresenceUpdateCallsCount += 1
-        ablySubscriberDidReceivePresenceUpdateReceivedArguments = (sender: sender, presence: presence)
-        ablySubscriberDidReceivePresenceUpdateReceivedInvocations.append((sender: sender, presence: presence))
-        ablySubscriberDidReceivePresenceUpdateClosure?(sender, presence)
+    public func ablySubscriber(_ sender: AblySubscriber, didReceivePresenceMessage presence: PresenceMessage) {
+        ablySubscriberDidReceivePresenceMessageCallsCount += 1
+        ablySubscriberDidReceivePresenceMessageReceivedArguments = (sender: sender, presence: presence)
+        ablySubscriberDidReceivePresenceMessageReceivedInvocations.append((sender: sender, presence: presence))
+        ablySubscriberDidReceivePresenceMessageClosure?(sender, presence)
     }
 
     //MARK: - ablySubscriber


### PR DESCRIPTION
The name is misleading — makes it sound like the presence message is an `UPDATE`, but that’s not necessarily the case.