### PR TITLE
Do not emit a resolution to subscriber for `ABSENT` or `LEAVE` presence messages

### DIFF
--- a/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
+++ b/Sources/AblyAssetTrackingInternal/AblyWrapper/DefaultAbly.swift
@@ -319,7 +319,7 @@ public class DefaultAbly: AblyCommon {
         self.subscriberDelegate?.ablySubscriber(self, didChangeChannelConnectionState: presence.action.toConnectionState())
 
         // Deleagate `Publisher` resolution if present in PresenceData
-        if let resolution = data.resolution, data.type == .publisher {
+        if let resolution = data.resolution, data.type == .publisher, ![.absent, .leave].contains(presence.action) {
             self.subscriberDelegate?.ablySubscriber(self, didReceiveResolution: resolution)
         }
 


### PR DESCRIPTION
This mimics the behaviour of Android’s `updateForPresenceMessagesAndThenEmitStateEventsIfRequired` at commit `4d13ae7`.

I’ve only added this piecemeal change to get the `Null*` subscriber network connectivity tests to pass (see [this comment](https://github.com/ably/ably-asset-tracking-swift/pull/612#discussion_r1143052156)). We’ll be removing this code soon enough as part of our Android parity work, so I haven’t bothered changing the tests since this part of the code is currently untested anyway.