### PR TITLE
Add reusable unit tests for `DefaultWorker` workers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,8 @@ let package = Package(
         .target(
             name: "AblyAssetTrackingInternalTesting",
             dependencies: [
-                "AblyAssetTrackingInternal"
+                "AblyAssetTrackingInternal",
+                "AblyAssetTrackingTesting"
             ],
             path: "Tests/Support/AblyAssetTrackingInternalTesting"
         ),

--- a/Sources/AblyAssetTrackingInternal/WorkerQueue/Worker.swift
+++ b/Sources/AblyAssetTrackingInternal/WorkerQueue/Worker.swift
@@ -51,11 +51,11 @@ public protocol Worker<PropertiesType, WorkerSpecificationType>: AnyObject {
 
 /// A protocol used to avoid duplication of default ``doWork``, ``doWhenStopped``,  ``onUnexpectedError`` and
 /// ``onUnexpectedAsyncError`` implementation for workers without callbacks
-protocol DefaultWorker<PropertiesType, WorkerSpecificationType>: Worker {}
+public protocol DefaultWorker<PropertiesType, WorkerSpecificationType>: Worker {}
 
 /// A protocol used to avoid duplication of default ``doWork``, ``doWhenStopped``,  ``onUnexpectedError`` and
 /// ``onUnexpectedAsyncError`` implementation for workers with a callback
-protocol CallbackWorker<PropertiesType, WorkerSpecificationType>: Worker {
+public protocol CallbackWorker<PropertiesType, WorkerSpecificationType>: Worker {
     var callbackFunction: ResultHandler<Void> { get set }
 }
 

--- a/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/WorkerQueue/DefaultWorkerTestEnvironment.swift
+++ b/Tests/Support/AblyAssetTrackingInternalTesting/Mocks/WorkerQueue/DefaultWorkerTestEnvironment.swift
@@ -1,0 +1,104 @@
+import AblyAssetTrackingInternal
+import AblyAssetTrackingTesting
+import XCTest
+
+/// A factory for creating workers to be tested by `DefaultWorkerTestEnvironment`.
+public protocol DefaultWorkerFactory<Worker> {
+    /// The type of worker created by this factory.
+    associatedtype Worker: DefaultWorker
+
+    /// Creates a new worker instance.
+    func createWorker() -> Worker
+}
+
+// An arbitrary error.
+private enum ExampleError: Error {
+    case example
+}
+
+/// Provides a set of unit tests for the default method implementations of the `DefaultWorker` protocol.
+///
+/// Intended to be used inside the unit tests of a worker type that conforms to `DefaultWorker`, to verify and document that it provides the expected behaviour.
+public struct DefaultWorkerTestEnvironment<WorkerFactory: DefaultWorkerFactory> {
+    private let workerFactory: WorkerFactory
+
+    /// Creates an instance of the test environment, for testing workers created by `factory`.
+    public init(factory: WorkerFactory) {
+        self.workerFactory = factory
+    }
+
+    /// Implements the following test cases:
+    ///
+    /// Given... a worker created by workerFactory
+    /// When... doWhenStopped is called on the worker, with an arbitrary error
+    /// Then... the worker does nothing
+    ///
+    /// Given... a worker created by workerFactory
+    /// When... onUnexpectedError is called on the worker, with an arbitrary error
+    /// Then... the worker does not post any work
+    ///
+    /// Given... a worker created by workerFactory
+    /// When... onUnexpectedAsyncError is called on the worker, with an arbitrary error
+    /// Then... the worker does not post any work
+    public func test() throws {
+        // swiftlint:disable opening_brace
+        let tests = [
+            { try performTest_doWhenStopped() },
+            { try performTest_onUnexpectedError() },
+            { try performTest_onUnexpectedAsyncError() }
+        ]
+        // swiftlint:enable opening_brace
+
+        try tests.reduce(into: MultipleErrors()) { multipleErrors, test in
+            do {
+                try test()
+            } catch {
+                multipleErrors.add(error)
+            }
+        }
+        .check()
+    }
+
+    // Implements the following test case:
+    //
+    // Given... a worker created by workerFactory
+    // When... doWhenStopped is called on the worker, with an arbitrary error
+    // Then... the worker does nothing
+    private func performTest_doWhenStopped() throws {
+        let worker = workerFactory.createWorker()
+
+        worker.doWhenStopped(error: ExampleError.example)
+
+        // There's not really any assertion to make here
+    }
+
+    // Given... a worker created by workerFactory
+    // When... onUnexpectedError is called on the worker, with an arbitrary error
+    // Then... the worker does not post any work
+    private func performTest_onUnexpectedError() throws {
+        let worker = workerFactory.createWorker()
+
+        var postedWork = false
+
+        worker.onUnexpectedError(error: ExampleError.example) { _ in
+            postedWork = true
+        }
+
+        XCTAssertFalse(postedWork)
+    }
+
+    // Given... a worker created by workerFactory
+    // When... onUnexpectedAsyncError is called on the worker, with an arbitrary error
+    // Then... the worker does not post any work
+    private func performTest_onUnexpectedAsyncError() throws {
+        let worker = workerFactory.createWorker()
+
+        var postedWork = false
+
+        worker.onUnexpectedAsyncError(error: ExampleError.example) { _ in
+            postedWork = true
+        }
+
+        XCTAssertFalse(postedWork)
+    }
+}


### PR DESCRIPTION
**Note: this is based on top of #539 (it reuses the `MultipleErrors` type). Please don't merge this one until that one is merged.**

This adds a set of reusable unit tests that verify that a worker type provides the behaviours implemented by the `DefaultWorker` protocol.

I’ll first be using it in the unit tests for the upcoming `UpdatePublisherPresence` worker. [Here](https://github.com/ably/ably-asset-tracking-swift/commit/b6f1ceccde4d7dc4524f1e223a7f58cc5b6b24c3#diff-0af9e66ea1c546d31e5eb296906a1b9565c8b39ce0b5eb1e52d473e41c3f77acR7-R27) is an example of how it looks in action.

See commit messages for more details.