### PR TITLE
Use HTTPS for submodules, not SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/common"]
 	path = external/common
-	url = git@github.com:ably/ably-asset-tracking-common.git
+	url = https://github.com/ably/ably-asset-tracking-common.git
 [submodule "external/sdk-test-proxy"]
 	path = external/sdk-test-proxy
-	url = git@github.com:ably/sdk-test-proxy.git
+	url = https://github.com/ably/sdk-test-proxy.git


### PR DESCRIPTION
We don’t want users to need an SSH key set up in order to be able to install our package using Swift Package Manager.