### PR TITLE
Fix publisher example app build error in Xcode 14.3.1

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
         with:
@@ -14,7 +14,7 @@ jobs:
 
       - name: Select Specific Xcode Version
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.2.app
+          sudo xcode-select -s /Applications/Xcode_14.3.1.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       MINT_PATH: .mint/lib
       MINT_LINK_PATH: .mint/bin
@@ -17,7 +17,7 @@ jobs:
 
       - name: Select Specific Xcode Version
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.2.app
+          sudo xcode-select -s /Applications/Xcode_14.3.1.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     permissions:
       deployments: write
       id-token: write
@@ -17,7 +17,7 @@ jobs:
 
       - name: Select Specific Xcode Version
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.2.app
+          sudo xcode-select -s /Applications/Xcode_14.3.1.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/AblyAssetTracking.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "d1bbbe0d4e89dde4da19c83a5edabf7ad6b2bd1f",
-        "version" : "2.0.0"
+        "revision" : "10e03f16a071382b83e1ebc37f8d3aca6cdab825",
+        "version" : "2.11.7"
+      }
+    },
+    {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "f970384ad1035732f99259255cd2f97564807e41",
+        "version" : "1.1.0"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "da88cf1cab82e281e7277cd9feb9efc87a057041",
-        "version" : "2.1.1"
+        "revision" : "b036e83716789c13a3480eeb292b70caa54114f2",
+        "version" : "3.1.0"
       }
     },
     {
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "d654b82a55aec736ad8b4354027acab17394a060",
-        "version" : "0.2.2"
+        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "76d1b43bfc3eeafd9d09e5aa307e629882192a7d",
-        "version" : "0.2.7"
+        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
+        "version" : "0.13.0"
       }
     },
     {
@@ -248,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "83de16a9d66c942248305aafd57f842eb2363358",
-        "version" : "0.2.5"
+        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+        "version" : "0.15.0"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These SDKs support support iOS and iPadOS. Support for macOS/ tvOS may be develo
 
 - Subscriber SDK: iOS 13.0+ / iPadOS 13.0+
 
-- Xcode 14.0+
+- Xcode 14.0+ (we currently test using Xcode 14.3.1)
 
 - Swift 5.7+
 

--- a/Scripts/assemble.sh
+++ b/Scripts/assemble.sh
@@ -25,11 +25,11 @@ echo
 echo '\033[1mBuild: SubscriberExample\033[0m'
 echo
 
-xcodebuild build -scheme "SubscriberExample" -workspace "./Examples/AblyAssetTracking.xcworkspace" -destination "platform=iOS Simulator,name=iPhone 13" -configuration "Debug" | xcpretty
+xcodebuild build -scheme "SubscriberExample" -workspace "./Examples/AblyAssetTracking.xcworkspace" -destination "platform=iOS Simulator,name=iPhone 14" -configuration "Debug" | xcpretty
 
 # Publisher Example (SwiftUI)
 echo
 echo '\033[1mBuild: PublisherExample (SwiftUI)\033[0m'
 echo
 
-xcodebuild build -scheme "PublisherExampleSwiftUI" -workspace "./Examples/AblyAssetTracking.xcworkspace" -destination "platform=iOS Simulator,name=iPhone 13" -configuration "Debug" | xcpretty
+xcodebuild build -scheme "PublisherExampleSwiftUI" -workspace "./Examples/AblyAssetTracking.xcworkspace" -destination "platform=iOS Simulator,name=iPhone 14" -configuration "Debug" | xcpretty


### PR DESCRIPTION
This fixes a compilation error when trying to build the publisher example app in Xcode 14.3.1. See commit messages for more details.