### PR TITLE
Fix example app instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ _You can find the version on the [releases](https://github.com/ably/ably-asset-t
 
 - If you have not already, [configure your development machine](#mapbox-setup) so that it has permissions to download the Mapbox Navigation SDK.
 - An `Examples/Secrets.xcconfig` file containing credentials (keys/ tokens) is required to build the example apps. (You can use the example `Examples/Example.Secrets.xcconfig`, e.g. by running `cp Examples/Example.Secrets.xcconfig Examples/Secrets.xcconfig`). Update the following values in `Examples/Secrets.xcconfig`:
-- `ABLY_API_KEY`: Used by all example apps to authenticate with Ably using basic authentication. Not recommended in production, and can be taken from [here](https://ably.com/accounts).
-- `MAPBOX_ACCESS_TOKEN`: Used to access Mapbox Navigation SDK/ APIs, and can be taken from [here](https://account.mapbox.com/). Using the Mapbox token is only required to run the **Publisher** example apps.
+    - `ABLY_API_KEY`: Used by all example apps to authenticate with Ably using basic authentication. Not recommended in production, and can be taken from [here](https://ably.com/accounts).
+    - `MAPBOX_ACCESS_TOKEN`: Used to access Mapbox Navigation SDK/ APIs, and can be taken from [here](https://account.mapbox.com/). Using the Mapbox token is only required to run the **Publisher** example apps.
 - Open `AblyAssetTracking.xcworkspace` to open an Xcode workspace containing the Subscriber example app and the Swift Package containing the SDKs that showcase how to use the subscriber part of the Ably Asset Tracking SDKs.
 - Open `PublisherExample.xcodeproj` to open an Xcode workspace containing the Publisher exmple app
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ _You can find the version on the [releases](https://github.com/ably/ably-asset-t
 - An `Examples/Secrets.xcconfig` file containing credentials (keys/ tokens) is required to build the example apps. (You can use the example `Examples/Example.Secrets.xcconfig`, e.g. by running `cp Examples/Example.Secrets.xcconfig Examples/Secrets.xcconfig`). Update the following values in `Examples/Secrets.xcconfig`:
     - `ABLY_API_KEY`: Used by all example apps to authenticate with Ably using basic authentication. Not recommended in production, and can be taken from [here](https://ably.com/accounts).
     - `MAPBOX_ACCESS_TOKEN`: Used to access Mapbox Navigation SDK/ APIs, and can be taken from [here](https://account.mapbox.com/). Using the Mapbox token is only required to run the **Publisher** example apps.
-- Open `AblyAssetTracking.xcworkspace` to open an Xcode workspace containing the Subscriber example app and the Swift Package containing the SDKs that showcase how to use the subscriber part of the Ably Asset Tracking SDKs.
-- Open `PublisherExample.xcodeproj` to open an Xcode workspace containing the Publisher exmple app
+- To run the example apps, open`AblyAssetTracking.xcworkspace` and then run the `PublisherExample` or `SubscriberExample` target.
 
 ### AWS S3 support in publisher app (optional)
 


### PR DESCRIPTION
Fixes the instructions in the `README` for running the example apps.